### PR TITLE
Add Rolling and Window Classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,10 @@ Provides the following methods for a Series:
 * `.where()`
 * `.abs()`
 * `.pow()`
+* `.count()`
 * `.mean()`
+* `.sum()`
+* `.std()`
 * `.quantile()`
 * `.dropna()`
 * `.fillna()`
@@ -61,7 +64,7 @@ Provides the following methods for a Series:
 * `.clip()`
 * `.apply()`
 * `<<` operator overloading (pretty printing)
-* `.rolling()` supporting mean, quantile, std, sum for flat windows, triangle windows, and exponential windows (approximated)
+* `.rolling()` supporting mean, quantile, std, sum for flat windows, triangle windows, and (approximated) exponential windows
 
 It also provides a SeriesMask class which is the result of any comparison operation and is used as the input to `.where()`.
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ What is coming up?
 * [ ] Example python bindings project
 * [ ] Further development and tests for TimeSeriesMask
 * [ ] LocalTimeSeries that works with `std::chrono::local_clock` where TimeSeries works with `std::chrono::system_clock` (i.e. utc)
-* [ ] Making `.rolling()` more pandas with `.rolling().mean()` syntax
+* [x] Making `.rolling()` more pandas with `.rolling().mean()` syntax
 * [ ] date literals for TimeSeries
 * [ ] `[]` syntax for subsetting Series
 * [ ] `EnumSeries` to support strongly typed categorical series

--- a/src/cpp/polars/Series.cpp
+++ b/src/cpp/polars/Series.cpp
@@ -400,6 +400,11 @@ namespace polars {
     }
 
 
+    int Series::count() const {
+        return finiteSize();
+    }
+
+
     double Series::sum() const {
         arma::vec finites = finiteValues();
         if (finites.size() == 0) {

--- a/src/cpp/polars/Series.cpp
+++ b/src/cpp/polars/Series.cpp
@@ -425,13 +425,18 @@ namespace polars {
     }
 
 
-    double Series::std() const {
+    double Series::std(int ddof) const {
         arma::vec finites = finiteValues();
-        if (finites.size() == 0) {
+        if (ddof < 0) {
+            ddof = 0;
+        }
+        auto n = finites.size();
+        if (n <= ddof) {
             return NAN;
         } else {
             auto dev = (*this) - this->mean();
-            return std::pow(dev.pow(2).mean(), 0.5);
+            auto squared_deviation = dev.pow(2);
+            return std::pow(squared_deviation.sum() / (n - ddof), 0.5);
         }
     }
 

--- a/src/cpp/polars/Series.cpp
+++ b/src/cpp/polars/Series.cpp
@@ -400,12 +400,33 @@ namespace polars {
     }
 
 
+    double Series::sum() const {
+        arma::vec finites = finiteValues();
+        if (finites.size() == 0) {
+            return NAN;
+        } else {
+            return arma::sum(finites);
+        }
+    }
+
+
     double Series::mean() const {
         arma::vec finites = finiteValues();
         if (finites.size() == 0) {
             return NAN;
         } else {
             return arma::mean(finites);
+        }
+    }
+
+
+    double Series::std() const {
+        arma::vec finites = finiteValues();
+        if (finites.size() == 0) {
+            return NAN;
+        } else {
+            auto dev = (*this) - this->mean();
+            return std::pow(dev.pow(2).mean(), 0.5);
         }
     }
 

--- a/src/cpp/polars/Series.cpp
+++ b/src/cpp/polars/Series.cpp
@@ -371,6 +371,22 @@ namespace polars {
 
     }
 
+    Window Series::rolling(SeriesSize windowSize,
+                   SeriesSize minPeriods,
+                   bool center,
+                   bool symmetric,
+                   polars::WindowProcessor::WindowType win_type,
+                   double alpha) const {
+        return Window((*this), windowSize, minPeriods, center, symmetric, win_type, alpha);
+    };
+
+    Rolling Series::rolling(SeriesSize windowSize,
+                    SeriesSize minPeriods,
+                    bool center,
+                    bool symmetric) const {
+        return Rolling((*this), windowSize, minPeriods, center, symmetric);
+    };
+
 
     Series Series::clip(double lower_limit, double upper_limit) const {
         SeriesMask upper = SeriesMask(values() < upper_limit, index());

--- a/src/cpp/polars/Series.h
+++ b/src/cpp/polars/Series.h
@@ -104,7 +104,11 @@ namespace polars {
 
         Series apply(double (*f)(double)) const;
 
+        double sum() const;
+
         double mean() const;
+
+        double std() const;
 
         SeriesSize size() const;
 

--- a/src/cpp/polars/Series.h
+++ b/src/cpp/polars/Series.h
@@ -110,7 +110,7 @@ namespace polars {
 
         double mean() const;
 
-        double std() const;
+        double std(int ddof=1) const;
 
         SeriesSize size() const;
 

--- a/src/cpp/polars/Series.h
+++ b/src/cpp/polars/Series.h
@@ -104,6 +104,8 @@ namespace polars {
 
         Series apply(double (*f)(double)) const;
 
+        int count() const;
+
         double sum() const;
 
         double mean() const;

--- a/src/cpp/polars/Series.h
+++ b/src/cpp/polars/Series.h
@@ -90,6 +90,18 @@ namespace polars {
                        WindowProcessor::WindowType win_type = WindowProcessor::WindowType::none,
                        double alpha = -1) const;
 
+        Window rolling(SeriesSize windowSize,
+                       SeriesSize minPeriods = 0, /* 0 treated as windowSize */
+                       bool center = true,
+                       bool symmetric = false,
+                       polars::WindowProcessor::WindowType win_type = polars::WindowProcessor::WindowType::none,
+                       double alpha = -1) const;
+
+        Rolling rolling(SeriesSize windowSize,
+                        SeriesSize minPeriods = 0, /* 0 treated as windowSize */
+                        bool center = true,
+                        bool symmetric = false) const;
+
         Series apply(double (*f)(double)) const;
 
         double mean() const;

--- a/src/cpp/polars/WindowProcessor.cpp
+++ b/src/cpp/polars/WindowProcessor.cpp
@@ -64,6 +64,16 @@ namespace polars {
         return polars::numc::sum_finite(weighted_values) / arma::sum(weights);
     }
 
+
+    polars::Std::Std(double default_value) : default_value(default_value) {}
+
+
+    double polars::Std::processWindow(const Series &window, const arma::vec& weights) const {
+        auto weighted_series = Series(window.values() % weights, window.index());
+        return weighted_series.std();
+    }
+
+
     double polars::ExpMean::processWindow(const Series &window, const arma::vec& weights) const {
         // This ensures deals with NAs like pandas for the case ignore_na = False which is the default setting.
         arma::vec weights_for_sum = weights.elem(arma::find_finite(window.values()));
@@ -71,20 +81,24 @@ namespace polars {
         return polars::numc::sum_finite(weighted_values) / arma::sum(weights_for_sum);
     }
 
-    Series Rolling::mean() {
-        return ts_.rolling(windowSize_, Mean(), minPeriods_, center_, symmetric_);
-    }
-
-    Series Rolling::quantile(int q) {
-        return ts_.rolling(windowSize_, Quantile(q), minPeriods_, center_, symmetric_);
+    Series Rolling::count() {
+        return ts_.rolling(windowSize_, Count(), minPeriods_, center_, symmetric_);
     }
 
     Series Rolling::sum() {
         return ts_.rolling(windowSize_, Sum(), minPeriods_, center_, symmetric_);
     }
 
-    Series Rolling::count() {
-        return ts_.rolling(windowSize_, Count(), minPeriods_, center_, symmetric_);
+    Series Rolling::mean() {
+        return ts_.rolling(windowSize_, Mean(), minPeriods_, center_, symmetric_);
+    }
+
+    Series Rolling::std() {
+        return ts_.rolling(windowSize_, Std(), minPeriods_, center_, symmetric_);
+    }
+
+    Series Rolling::quantile(int q) {
+        return ts_.rolling(windowSize_, Quantile(q), minPeriods_, center_, symmetric_);
     }
 
     Series Window::mean() {

--- a/src/cpp/polars/WindowProcessor.cpp
+++ b/src/cpp/polars/WindowProcessor.cpp
@@ -71,4 +71,20 @@ namespace polars {
         return polars::numc::sum_finite(weighted_values) / arma::sum(weights_for_sum);
     }
 
+    Series Rolling::mean() {
+        return ts_.rolling(windowSize_, Mean(), minPeriods_, center_, symmetric_);
+    }
+
+    Series Rolling::quantile(int q) {
+        return ts_.rolling(windowSize_, Quantile(q), minPeriods_, center_, symmetric_);
+    }
+
+    Series Window::mean() {
+        return ts_.rolling(windowSize_, Mean(), minPeriods_, center_, symmetric_, win_type_, alpha_);
+    }
+
+    Series Window::quantile(int q) {
+        return ts_.rolling(windowSize_, Quantile(q), minPeriods_, center_, symmetric_, win_type_, alpha_);
+    }
+
 } // polars

--- a/src/cpp/polars/WindowProcessor.h
+++ b/src/cpp/polars/WindowProcessor.h
@@ -103,6 +103,66 @@ namespace polars {
 
     arma::vec _ewm_correction(const arma::vec &results, const arma::vec &v0, polars::WindowProcessor::WindowType win_type);
 
+    class Rolling {
+    public:
+        Rolling(
+                const Series& ts,
+                arma::uword windowSize,
+                arma::uword minPeriods = 0, /* 0 treated as windowSize */
+                bool center = true,
+                bool symmetric = false)
+                :
+                ts_(ts),
+                windowSize_(windowSize),
+                minPeriods_(minPeriods),
+                center_(center),
+                symmetric_(symmetric)
+        {};
+
+        Series mean();
+        Series quantile(int q);
+    private:
+        const Series& ts_;
+        arma::uword windowSize_;
+        arma::uword minPeriods_;
+        bool center_;
+        bool symmetric_;
+    };
+
+
+    class Window {
+    public:
+        Window(
+                const Series &ts,
+                arma::uword windowSize,
+                arma::uword minPeriods = 0, /* 0 treated as windowSize */
+                bool center = true,
+                bool symmetric = false,
+                polars::WindowProcessor::WindowType win_type = polars::WindowProcessor::WindowType::none,
+                double alpha = -1)
+                :
+                ts_(ts),
+                windowSize_(windowSize),
+                minPeriods_(minPeriods),
+                center_(center),
+                symmetric_(symmetric),
+                win_type_(win_type),
+                alpha_(alpha) {};
+
+        Series mean();
+
+        Series quantile(int q);
+
+    private:
+        const Series &ts_;
+        arma::uword windowSize_;
+        arma::uword minPeriods_;
+        bool center_;
+        bool symmetric_;
+        polars::WindowProcessor::WindowType win_type_;
+        double alpha_;
+    };
+
 }  // polars
 
 

--- a/src/cpp/polars/WindowProcessor.h
+++ b/src/cpp/polars/WindowProcessor.h
@@ -84,6 +84,22 @@ namespace polars {
         double default_value = NAN;
     };
 
+    class Std : public WindowProcessor {
+    public:
+        Std() = default;
+
+        Std(double default_value);
+
+        double processWindow(const Series &window, const arma::vec& weights = {}) const;
+
+        inline double defaultValue() const {
+            return default_value;
+        }
+
+    private:
+        double default_value = NAN;
+    };
+
     class ExpMean : public WindowProcessor {
     public:
         ExpMean() = default;
@@ -119,10 +135,11 @@ namespace polars {
                 symmetric_(symmetric)
         {};
 
-        Series mean();
-        Series quantile(int q);
-        Series sum();
         Series count();
+        Series sum();
+        Series mean();
+        Series std();
+        Series quantile(int q);
     private:
         const Series& ts_;
         arma::uword windowSize_;

--- a/src/cpp/polars/WindowProcessor.h
+++ b/src/cpp/polars/WindowProcessor.h
@@ -21,7 +21,7 @@ namespace polars {
             expn
         };
 
-        virtual double processWindow(const Series &window, const arma::vec weights) const = 0;
+        virtual double processWindow(const Series &window, const arma::vec& weights) const = 0;
 
         virtual double defaultValue() const = 0;
     };
@@ -31,7 +31,7 @@ namespace polars {
     public:
         Quantile(double quantile);
 
-        double processWindow(const Series &window, const arma::vec weights = {}) const;
+        double processWindow(const Series &window, const arma::vec& weights = {}) const;
 
         inline double defaultValue() const {
             return NAN;
@@ -45,7 +45,7 @@ namespace polars {
     public:
         Sum() = default;
 
-        double processWindow(const Series &window, const arma::vec weights = {}) const;
+        double processWindow(const Series &window, const arma::vec& weights = {}) const;
 
         inline double defaultValue() const {
             return NAN;
@@ -58,7 +58,7 @@ namespace polars {
 
         Count(double default_value);
 
-        double processWindow(const Series &window, const arma::vec weights = {}) const;
+        double processWindow(const Series &window, const arma::vec& weights = {}) const;
 
         inline double defaultValue() const {
             return default_value;
@@ -74,7 +74,7 @@ namespace polars {
 
         Mean(double default_value);
 
-        double processWindow(const Series &window, const arma::vec weights = {}) const;
+        double processWindow(const Series &window, const arma::vec& weights = {}) const;
 
         inline double defaultValue() const {
             return default_value;
@@ -88,7 +88,7 @@ namespace polars {
     public:
         ExpMean() = default;
 
-        double processWindow(const Series &window, const arma::vec weights = {}) const;
+        double processWindow(const Series &window, const arma::vec& weights = {}) const;
 
         inline double defaultValue() const {
             return default_value;
@@ -121,6 +121,8 @@ namespace polars {
 
         Series mean();
         Series quantile(int q);
+        Series sum();
+        Series count();
     private:
         const Series& ts_;
         arma::uword windowSize_;
@@ -151,7 +153,7 @@ namespace polars {
 
         Series mean();
 
-        Series quantile(int q);
+        Series sum();
 
     private:
         const Series &ts_;

--- a/tests/test_cpp/polars/TestSeries.cpp
+++ b/tests/test_cpp/polars/TestSeries.cpp
@@ -216,13 +216,20 @@ namespace SeriesTests {
     }
 
     TEST(Series, StdTest) {
-        EXPECT_EQ(Series(arma::vec({3, 4}), arma::vec({1, 2})).std(), 0.5)
+        auto root_2 = std::pow(2, .5);
+        EXPECT_FLOAT_EQ(Series(arma::vec({3, 4}), arma::vec({1, 2})).std(), 1 / root_2)
+                            << "Expect " << "simple std() fixture result to be correct" << "";
+
+        EXPECT_FLOAT_EQ(Series(arma::vec({3, 4}), arma::vec({1, 2})).std(0), 0.5)
                             << "Expect " << "simple std() fixture result to be correct" << "";
 
         ASSERT_TRUE(std::isnan(Series(arma::vec({}), arma::vec({})).std()))
                                     << "Expect " << "empty series std() should be NAN" << "";
 
-        EXPECT_EQ(Series(arma::vec({3, NAN, 4}), arma::vec({1, 2, 3})).std(), 0.5)
+        ASSERT_TRUE(std::isnan(Series(arma::vec({3}), arma::vec({1})).std()))
+                                    << "Expect " << "Series with 1 element std() should be NAN";
+
+        EXPECT_FLOAT_EQ(Series(arma::vec({3, NAN, 4}), arma::vec({1, 2, 3})).std(), 1 / root_2)
                             << "Expect " << "simple std() fixture result with NAN to be correct, ignoring NANs" << "";
 
 

--- a/tests/test_cpp/polars/TestSeries.cpp
+++ b/tests/test_cpp/polars/TestSeries.cpp
@@ -177,6 +177,19 @@ namespace SeriesTests {
         ) << "Expect " << "indices clipped to 2-3";
     }
 
+    TEST(Series, SumTest) {
+        EXPECT_EQ(Series(arma::vec({3, 4}), arma::vec({1, 2})).sum(), 7)
+                            << "Expect " << "simple sum() fixture result to be correct" << "";
+
+        ASSERT_TRUE(std::isnan(Series(arma::vec({}), arma::vec({})).sum()))
+                                    << "Expect " << "empty series sum() should be NAN" << "";
+
+        EXPECT_EQ(Series(arma::vec({3, NAN, 4}), arma::vec({1, 2, 3})).sum(), 7)
+                            << "Expect " << "simple sum() fixture result with NAN to be correct, ignoring NANs" << "";
+
+
+    }
+
     TEST(Series, MeanTest) {
         EXPECT_EQ(Series(arma::vec({3, 4}), arma::vec({1, 2})).mean(), 3.5)
                             << "Expect " << "simple mean() fixture result to be correct" << "";
@@ -186,6 +199,19 @@ namespace SeriesTests {
 
         EXPECT_EQ(Series(arma::vec({3, NAN, 4}), arma::vec({1, 2, 3})).mean(), 3.5)
                             << "Expect " << "simple mean() fixture result with NAN to be correct, ignoring NANs" << "";
+
+
+    }
+
+    TEST(Series, StdTest) {
+        EXPECT_EQ(Series(arma::vec({3, 4}), arma::vec({1, 2})).std(), 0.5)
+                            << "Expect " << "simple std() fixture result to be correct" << "";
+
+        ASSERT_TRUE(std::isnan(Series(arma::vec({}), arma::vec({})).std()))
+                                    << "Expect " << "empty series std() should be NAN" << "";
+
+        EXPECT_EQ(Series(arma::vec({3, NAN, 4}), arma::vec({1, 2, 3})).std(), 0.5)
+                            << "Expect " << "simple std() fixture result with NAN to be correct, ignoring NANs" << "";
 
 
     }

--- a/tests/test_cpp/polars/TestSeries.cpp
+++ b/tests/test_cpp/polars/TestSeries.cpp
@@ -177,6 +177,18 @@ namespace SeriesTests {
         ) << "Expect " << "indices clipped to 2-3";
     }
 
+    TEST(Series, CountTest) {
+        EXPECT_EQ(Series(arma::vec({3, 4}), arma::vec({1, 2})).count(), 2)
+                            << "Expect " << "simple count() fixture result to be correct" << "";
+
+        EXPECT_EQ(Series().count(), 0) << "Expect " << "empty series count() should be 0" << "";
+
+        EXPECT_EQ(Series(arma::vec({3, NAN, 4}), arma::vec({1, 2, 3})).count(), 2)
+                            << "Expect " << "simple count() fixture result with NAN to be correct, ignoring NANs" << "";
+
+
+    }
+
     TEST(Series, SumTest) {
         EXPECT_EQ(Series(arma::vec({3, 4}), arma::vec({1, 2})).sum(), 7)
                             << "Expect " << "simple sum() fixture result to be correct" << "";

--- a/tests/test_cpp/polars/TestWindowProcessor.cpp
+++ b/tests/test_cpp/polars/TestWindowProcessor.cpp
@@ -193,6 +193,12 @@ namespace WindowProcessorTests {
 
         EXPECT_PRED2(
                 Series::equal,
+                Series({1, 2, 3.5, -1, NAN}, {1, 2, 3, 4, 5}).rolling(1, 0, true, false, polars::WindowProcessor::WindowType::triang).mean(),
+                Series({1, 2, 3.5, -1, NAN}, {1, 2, 3, 4, 5})
+        ) << "Expect " << "with a window of 1 the indices is returned as is";
+
+        EXPECT_PRED2(
+                Series::equal,
                 Series({1, 2, 3}, {1, 2, 3}).rolling(3, polars::Mean(), 0, true, false, polars::WindowProcessor::WindowType::triang),
                 Series({NAN, 2, NAN}, {1, 2, 3})
         ) << "Expect " << "with a window of 3 the indices of length 3 returns just central value";
@@ -204,8 +210,20 @@ namespace WindowProcessorTests {
         ) << "Expect " << "with a window of 3 any windows with 3 non-NAN values should give weighted mean, not NAN";
 
         EXPECT_PRED2(
+                Series::equal,
+                Series({1, 2, 3.5, -1, NAN}, {1, 2, 3, 4, 5}).rolling(3, 0, true, false, polars::WindowProcessor::WindowType::triang).mean(),
+                Series({NAN, 2.125, 2.0, NAN, NAN}, {1, 2, 3, 4, 5})
+        ) << "Expect " << "with a window of 3 any windows with 3 non-NAN values should give weighted mean, not NAN";
+
+        EXPECT_PRED2(
                 Series::almost_equal,
                 Series({1, 2, 3, 4}, {1, 2, 3, 4}).rolling(5, polars::Mean(), 1, true, false, polars::WindowProcessor::WindowType::triang),
+                Series({1.66666667, 2.25, 2.75, 3.33333333}, {1, 2, 3, 4})
+        ) << "Expect " << "no NANs because min periods is 1.";
+
+        EXPECT_PRED2(
+                Series::almost_equal,
+                Series({1, 2, 3, 4}, {1, 2, 3, 4}).rolling(5, 1, true, false, polars::WindowProcessor::WindowType::triang).mean(),
                 Series({1.66666667, 2.25, 2.75, 3.33333333}, {1, 2, 3, 4})
         ) << "Expect " << "no NANs because min periods is 1.";
     }
@@ -218,6 +236,11 @@ namespace WindowProcessorTests {
                 Series({0.1, 0.16666666666666667, 0.24285714285714284, 0.32666666666666666}, {1, 2, 3, 4})
         ) << "Expect " << " first value to be the same as original series.";
 
+        EXPECT_PRED2(
+                Series::almost_equal,
+                Series({0.1, 0.2, 0.3, 0.4}, {1, 2, 3, 4}).rolling(4, polars::ExpMean(), 1, true, false, polars::WindowProcessor::WindowType::expn, 0.5),
+                Series({0.1, 0.16666666666666667, 0.24285714285714284, 0.32666666666666666}, {1, 2, 3, 4})
+        ) << "Expect " << " first value to be the same as original series.";
 
         EXPECT_PRED2(
                 Series::equal,

--- a/tests/test_cpp/polars/TestWindowProcessor.cpp
+++ b/tests/test_cpp/polars/TestWindowProcessor.cpp
@@ -88,6 +88,38 @@ namespace WindowProcessorTests {
     }
 
 
+    TEST(Series, rolling_std) {
+        EXPECT_PRED2(
+                Series::equal,
+                Series().rolling(5, polars::Std()),
+                Series()
+        ) << "Expect " << "empty Series returns empty Series";
+
+        EXPECT_PRED2(
+                Series::equal,
+                Series({1, 2, 3.5, -1, NAN}, {1, 2, 3, 4, 5}).rolling(1, polars::Std()),
+                Series({NAN, NAN, NAN, NAN, NAN}, {1, 2, 3, 4, 5})
+        ) << "Expect " << "with a window of 1 std is undefined so returns NA";
+
+        EXPECT_PRED2(
+                Series::almost_equal,
+                Series({1, 2, 3.5, -1, NAN}, {1, 2, 3, 4, 5}).rolling(3, polars::Std()),
+                Series({NAN, arma::stddev(arma::vec{1, 2, 3.5}), arma::stddev(arma::vec{2, 3.5, -1}), NAN, NAN}, {1, 2, 3, 4, 5})
+        ) << "Expect " << "with a window of 3 any windows with 3 non-NAN values should be the std, not NAN";
+
+        EXPECT_PRED2(
+                Series::equal,
+                Series({1, 2, 3.5, -1, NAN}, {1, 2, 3, 4, 5}).rolling(3, polars::Std(), 2),
+                Series({
+                    arma::stddev(arma::vec{1, 2}),
+                    arma::stddev(arma::vec{1, 2, 3.5}),
+                    arma::stddev(arma::vec{2, 3.5, -1}),
+                    arma::stddev(arma::vec{3.5, -1}),
+                    NAN}, {1, 2, 3, 4, 5})
+        ) << "Expect " << "with window=3, min_periods=2 any windows with 2 non-NAN values should be the std, not NAN";
+    }
+
+
     TEST(Series, rolling_count) {
         EXPECT_PRED2(
                 Series::equal,


### PR DESCRIPTION
This makes add `.rolling()` methods that will return a `Rolling` or `Window` object that have `.mean()` methods etc so that the more pythonic / pandas style can be used.

Based on the existing methods underneath so minimal extra testing needed.