### PR TITLE
 Add constructors to support creating a Series from a SeriesMask

### DIFF
--- a/src/cpp/polars/Series.cpp
+++ b/src/cpp/polars/Series.cpp
@@ -36,6 +36,14 @@ namespace polars {
         //assert(t.n_rows == v.n_rows);
     };
 
+    /**
+     * Converting constructor - this takes a SeriesMask and creates a Series from it.
+     *
+     * This is intentionally implicit (not marked explicit) so that a function expecting a Series can be passed a
+     * SeriesMask and it will be automatically converted since this is a loss-less process.
+     */
+    Series::Series(const SeriesMask &sm) : t(sm.index()), v(arma::conv_to<arma::vec>::from(sm.values())) {}
+
     Series Series::from_vect(const std::vector<double> &t_v, const std::vector<double> &v_v) {
         return Series(arma::conv_to<arma::vec>::from(v_v), arma::conv_to<arma::vec>::from(t_v));
     }

--- a/src/cpp/polars/Series.h
+++ b/src/cpp/polars/Series.h
@@ -27,6 +27,8 @@ namespace polars {
 
         Series(const arma::vec &v, const arma::vec &t);
 
+        Series(const SeriesMask &sm);
+
         static Series from_vect(const std::vector<double> &t_v, const std::vector<double> &v_v);
 
         static Series from_map(const std::map<double, double> &iv_map);

--- a/src/cpp/polars/TimeSeries.h
+++ b/src/cpp/polars/TimeSeries.h
@@ -7,6 +7,8 @@
 
 #include "Series.h"
 
+#include "TimeSeriesMask.h"
+
 #include "armadillo"
 #include "date/date.h"
 
@@ -25,7 +27,7 @@ namespace polars {
 
     template<class TimePointType>
     class TimeSeries : public Series {
-
+    using Mask = TimeSeriesMask<TimePointType>;
     public:
         // TODO:: Expose methods as required
         using Series::loc;
@@ -35,6 +37,14 @@ namespace polars {
         TimeSeries() = default;
 
         TimeSeries(arma::vec v0, std::vector<TimePointType> t0) : Series(v0, chrono_to_double_vector(t0)) {};
+
+        /**
+         * Converting constructor - this takes a TimeSeriesMask and creates a TimeSeries from it.
+         *
+         * This is intentionally implicit (not marked explicit) so that a function expecting a TimeSeries can be passed
+         * a TimeSeriesMask and it will be automatically converted since this is a loss-less process.
+         */
+        TimeSeries(const Mask &sm) : Series(arma::conv_to<arma::vec>::from(sm.values()), sm.index()) {}
 
         static TimeSeries from_map(const std::map<TimePointType, double> &iv_map) {
             arma::vec index(iv_map.size());

--- a/tests/test_cpp/polars/TestSeries.cpp
+++ b/tests/test_cpp/polars/TestSeries.cpp
@@ -11,602 +11,616 @@
 
 
 namespace SeriesTests {
-    using Series = polars::Series;
+using namespace polars;
 
-    TEST(Series, from_map) {
-        EXPECT_PRED2(Series::equal, Series::from_map({}), Series());
+TEST(Series, constructors) {
+    EXPECT_PRED2(Series::equal, Series(SeriesMask()), Series())
+    << "Expect constructing with empty SeriesMask is the same as empty constructor";
+    EXPECT_PRED2(Series::equal, Series(SeriesMask({true, false}, {1, 2})), Series({1, 0}, {1, 2}))
+    << "Expect true becomes 1 and false becomes 0";
 
-        EXPECT_PRED2(Series::equal, Series::from_map({{1, 3}, {2, 4}}), Series({3, 4}, {1, 2}));
+    auto foo = [](Series s){return s;};
+    EXPECT_PRED2(Series::equal, foo(SeriesMask({true, false}, {1, 2})), Series({1, 0}, {1, 2}))
+    << "Expect implicit conversion from SeriesMask to Series is possible so that you can pass a SeriesMask to a function expecting a Series";
 
-    }
+}
 
-    TEST(Series, equal) {
-        EXPECT_PRED2(Series::equal, Series(), Series()) << "Expect " << "empty Series' match";
+TEST(Series, from_map) {
+    EXPECT_PRED2(Series::equal, Series::from_map({}), Series());
 
-        EXPECT_PRED2(Series::equal, Series(arma::vec({3, 4}), arma::vec({1, 2})),
-                     Series(arma::vec({3, 4}), arma::vec({1, 2})));
+    EXPECT_PRED2(Series::equal, Series::from_map({{1, 3},
+                                                  {2, 4}}), Series({3, 4}, {1, 2}));
 
-        EXPECT_PRED2(Series::equal, Series(arma::vec({NAN}), arma::vec({1})),
-                     Series(arma::vec({NAN}), arma::vec({1})))
-                            << "Expect " << "simple indices with NAN match";
+}
 
-        EXPECT_PRED2(Series::equal, Series(arma::vec({}), arma::vec({})),
-                     Series(arma::vec({}), arma::vec({})))
-                            << "Expect " << "empty indices match";
+TEST(Series, equal) {
+    EXPECT_PRED2(Series::equal, Series(), Series()) << "Expect " << "empty Series' match";
 
-        EXPECT_PRED2(Series::equal, Series(arma::vec({4, NAN, 5, NAN, NAN, 6}), arma::vec({1, 2, 3, 4, 5, 6})),
-                     Series(arma::vec({4, NAN, 5, NAN, NAN, 6}), arma::vec({1, 2, 3, 4, 5, 6})))
-                            << "Expect " << "longer indices with NANs match";
-    }
+    EXPECT_PRED2(Series::equal, Series(arma::vec({3, 4}), arma::vec({1, 2})),
+                 Series(arma::vec({3, 4}), arma::vec({1, 2})));
 
-    TEST(Series, not_equal) {
-        EXPECT_PRED2(Series::not_equal, Series(arma::vec({3, 4}), arma::vec({1, 2})),
-                     Series(arma::vec({1, 2}), arma::vec({1, 2})))
-                            << "Expect " << "index match does not imply Series match";
+    EXPECT_PRED2(Series::equal, Series(arma::vec({NAN}), arma::vec({1})),
+                 Series(arma::vec({NAN}), arma::vec({1})))
+                        << "Expect " << "simple indices with NAN match";
 
-        EXPECT_PRED2(Series::not_equal, Series(arma::vec({3, 4}), arma::vec({1, 2})),
-                     Series(arma::vec({3, 4}), arma::vec({3, 4})))
-                            << "Expect " << "values match does not imply Series match";
+    EXPECT_PRED2(Series::equal, Series(arma::vec({}), arma::vec({})),
+                 Series(arma::vec({}), arma::vec({})))
+                        << "Expect " << "empty indices match";
 
-        EXPECT_PRED2(Series::not_equal, Series(arma::vec({3, 4}), arma::vec({1, 2})),
-                     Series(arma::vec({1, 2}), arma::vec({3, 4})))
-                            << "Expect " << "swapping index and values results in no match" << "";
-    }
+    EXPECT_PRED2(Series::equal, Series(arma::vec({4, NAN, 5, NAN, NAN, 6}), arma::vec({1, 2, 3, 4, 5, 6})),
+                 Series(arma::vec({4, NAN, 5, NAN, NAN, 6}), arma::vec({1, 2, 3, 4, 5, 6})))
+                        << "Expect " << "longer indices with NANs match";
+}
 
-    TEST(Series, where) {
-        EXPECT_PRED2(
-                Series::equal,
-                Series({3, 4}, {1, 2}).where(polars::SeriesMask({0, 1}, {1, 2}), 17),
-                Series({17, 4}, {1, 2})
-        ) << "Expect " << "simple where()  to select correctly";
+TEST(Series, not_equal) {
+    EXPECT_PRED2(Series::not_equal, Series(arma::vec({3, 4}), arma::vec({1, 2})),
+                 Series(arma::vec({1, 2}), arma::vec({1, 2})))
+                        << "Expect " << "index match does not imply Series match";
 
-        EXPECT_PRED2(
-                Series::equal,
-                Series({3, 4}, {1, 2}).where(polars::SeriesMask({0, 1}, {1, 2}), NAN),
-                Series({NAN, 4}, {1, 2})
-        ) << "Expect " << ".where(..., NAN) to not set everything to NAN";
-    }
+    EXPECT_PRED2(Series::not_equal, Series(arma::vec({3, 4}), arma::vec({1, 2})),
+                 Series(arma::vec({3, 4}), arma::vec({3, 4})))
+                        << "Expect " << "values match does not imply Series match";
 
-    TEST(Series, DiffTest) {
-        EXPECT_PRED2(Series::equal, Series(arma::vec({3, 4}), arma::vec({1, 2})).diff(),
-                     Series(arma::vec({NAN, 1}), arma::vec({1, 2})))
-                            << "Expect " << "simple diff() fixture result to be correct" << "";
+    EXPECT_PRED2(Series::not_equal, Series(arma::vec({3, 4}), arma::vec({1, 2})),
+                 Series(arma::vec({1, 2}), arma::vec({3, 4})))
+                        << "Expect " << "swapping index and values results in no match" << "";
+}
 
-        EXPECT_PRED2(Series::equal, Series(arma::vec({4, 3}), arma::vec({1, 2})).diff(),
-                     Series(arma::vec({NAN, -1}), arma::vec({1, 2})))
-                            << "Expect " << "simple diff() fixture result to be correct" << "";
+TEST(Series, where) {
+    EXPECT_PRED2(
+            Series::equal,
+            Series({3, 4}, {1, 2}).where(polars::SeriesMask({0, 1}, {1, 2}), 17),
+            Series({17, 4}, {1, 2})
+    ) << "Expect " << "simple where()  to select correctly";
 
-        EXPECT_PRED2(Series::equal, Series(arma::vec({3}), arma::vec({1})).diff(),
-                     Series(arma::vec({NAN}), arma::vec({1})))
-                            << "Expect " << "simple diff() fixture result to be correct" << "";
+    EXPECT_PRED2(
+            Series::equal,
+            Series({3, 4}, {1, 2}).where(polars::SeriesMask({0, 1}, {1, 2}), NAN),
+            Series({NAN, 4}, {1, 2})
+    ) << "Expect " << ".where(..., NAN) to not set everything to NAN";
+}
 
-        EXPECT_PRED2(Series::equal, Series(arma::vec({}), arma::vec({})).diff(),
-                     Series(arma::vec({}), arma::vec({})))
-                            << "Expect " << "exmpty indices diff() fixture result to be correct" << "";
-    }
+TEST(Series, DiffTest) {
+    EXPECT_PRED2(Series::equal, Series(arma::vec({3, 4}), arma::vec({1, 2})).diff(),
+                 Series(arma::vec({NAN, 1}), arma::vec({1, 2})))
+                        << "Expect " << "simple diff() fixture result to be correct" << "";
 
-    TEST(Series, abs) {
-        EXPECT_PRED2(Series::equal,
-                     Series(arma::vec({0, 3, 4, -2, 1.5, NAN}), arma::vec({1, 2, 3, 4, 5, 6})).abs(),
-                     Series(arma::vec({0, 3, 4, 2, 1.5, NAN}), arma::vec({1, 2, 3, 4, 5, 6})))
-                            << "Expect " << "negative values to be positive and rest to remain the same.";
+    EXPECT_PRED2(Series::equal, Series(arma::vec({4, 3}), arma::vec({1, 2})).diff(),
+                 Series(arma::vec({NAN, -1}), arma::vec({1, 2})))
+                        << "Expect " << "simple diff() fixture result to be correct" << "";
 
-        EXPECT_PRED2(Series::equal, Series(arma::vec({}), arma::vec({})).pow(2),
-                     Series(arma::vec({}), arma::vec({})))
-                            << "Expect " << "empty Series .abs() to return empty Series";
-    }
+    EXPECT_PRED2(Series::equal, Series(arma::vec({3}), arma::vec({1})).diff(),
+                 Series(arma::vec({NAN}), arma::vec({1})))
+                        << "Expect " << "simple diff() fixture result to be correct" << "";
 
-    TEST(Series, PowTest) {
-        EXPECT_PRED2(Series::equal, Series(arma::vec({3, 4}), arma::vec({1, 2})).pow(2),
-                     Series(arma::vec({9, 16}), arma::vec({1, 2})))
-                            << "Expect " << "simple pow() fixture result to be correct" << "";
+    EXPECT_PRED2(Series::equal, Series(arma::vec({}), arma::vec({})).diff(),
+                 Series(arma::vec({}), arma::vec({})))
+                        << "Expect " << "exmpty indices diff() fixture result to be correct" << "";
+}
 
-        EXPECT_PRED2(Series::equal, Series(arma::vec({3, 4}), arma::vec({1, 2})).pow(3),
-                     Series(arma::vec({27, 64}), arma::vec({1, 2})))
-                            << "Expect " << "simple pow() fixture result to be correct" << "";
+TEST(Series, abs) {
+    EXPECT_PRED2(Series::equal,
+                 Series(arma::vec({0, 3, 4, -2, 1.5, NAN}), arma::vec({1, 2, 3, 4, 5, 6})).abs(),
+                 Series(arma::vec({0, 3, 4, 2, 1.5, NAN}), arma::vec({1, 2, 3, 4, 5, 6})))
+                        << "Expect " << "negative values to be positive and rest to remain the same.";
 
-        EXPECT_PRED2(Series::equal, Series(arma::vec({9}), arma::vec({1})).pow(0.5),
-                     Series(arma::vec({3}), arma::vec({1})))
-                            << "Expect " << "simple pow() fixture result to be correct" << "";
+    EXPECT_PRED2(Series::equal, Series(arma::vec({}), arma::vec({})).pow(2),
+                 Series(arma::vec({}), arma::vec({})))
+                        << "Expect " << "empty Series .abs() to return empty Series";
+}
 
-        EXPECT_PRED2(Series::equal, Series(arma::vec({}), arma::vec({})).pow(2),
-                     Series(arma::vec({}), arma::vec({})))
-                            << "Expect " << "empty indices pow() fixture result to be correct" << "";
-    }
+TEST(Series, PowTest) {
+    EXPECT_PRED2(Series::equal, Series(arma::vec({3, 4}), arma::vec({1, 2})).pow(2),
+                 Series(arma::vec({9, 16}), arma::vec({1, 2})))
+                        << "Expect " << "simple pow() fixture result to be correct" << "";
 
-    TEST(Series, fillna){
-        EXPECT_PRED2(
-                Series::equal,
-                Series({1, 0, 3, 0, 5}, {1, 2, 3, 4, 5}),
-                Series({1, NAN, 3, NAN, 5}, {1, 2, 3, 4, 5}).fillna()
-        ) << "Expect " << "replace NANs with zeros";
+    EXPECT_PRED2(Series::equal, Series(arma::vec({3, 4}), arma::vec({1, 2})).pow(3),
+                 Series(arma::vec({27, 64}), arma::vec({1, 2})))
+                        << "Expect " << "simple pow() fixture result to be correct" << "";
 
-        EXPECT_PRED2(
-                Series::equal,
-                Series({1, 1, 3, 1, 5}, {1, 2, 3, 4, 5}),
-                Series({1, NAN, 3, NAN, 5}, {1, 2, 3, 4, 5}).fillna(1.)
-        ) << "Expect " << "replace NANs with ones";
+    EXPECT_PRED2(Series::equal, Series(arma::vec({9}), arma::vec({1})).pow(0.5),
+                 Series(arma::vec({3}), arma::vec({1})))
+                        << "Expect " << "simple pow() fixture result to be correct" << "";
 
-        EXPECT_PRED2(
-                Series::equal,
-                Series({1, 2, 3, 4, 5}, {1, 2, 3, 4, 5}),
-                Series({1, 2, 3, 4, 5}, {1, 2, 3, 4, 5}).fillna()
-        ) << "Expect " << " remains the same as no NANs";
+    EXPECT_PRED2(Series::equal, Series(arma::vec({}), arma::vec({})).pow(2),
+                 Series(arma::vec({}), arma::vec({})))
+                        << "Expect " << "empty indices pow() fixture result to be correct" << "";
+}
 
-        EXPECT_PRED2(
-                Series::equal,
-                Series(),
-                Series().fillna()
-        ) << "Expect " << " empty array";
+TEST(Series, fillna) {
+    EXPECT_PRED2(
+            Series::equal,
+            Series({1, 0, 3, 0, 5}, {1, 2, 3, 4, 5}),
+            Series({1, NAN, 3, NAN, 5}, {1, 2, 3, 4, 5}).fillna()
+    ) << "Expect " << "replace NANs with zeros";
 
-    }
+    EXPECT_PRED2(
+            Series::equal,
+            Series({1, 1, 3, 1, 5}, {1, 2, 3, 4, 5}),
+            Series({1, NAN, 3, NAN, 5}, {1, 2, 3, 4, 5}).fillna(1.)
+    ) << "Expect " << "replace NANs with ones";
 
-    TEST(Series, dropna) {
-        EXPECT_PRED2(
-                Series::equal,
-                Series({1, 3, 5}, {1, 3, 5}),
-                Series({1, NAN, 3, NAN, 5}, {1, 2, 3, 4, 5}).dropna()
-        ) << "Expect " << "drop NANs so indices only contains finite elements";
+    EXPECT_PRED2(
+            Series::equal,
+            Series({1, 2, 3, 4, 5}, {1, 2, 3, 4, 5}),
+            Series({1, 2, 3, 4, 5}, {1, 2, 3, 4, 5}).fillna()
+    ) << "Expect " << " remains the same as no NANs";
 
-        EXPECT_PRED2(
-                Series::equal,
-                Series({1, 2, 3, 4, 5}, {1, 2, 3, 4, 5}),
-                Series({1, 2, 3, 4, 5}, {1, 2, 3, 4, 5}).dropna()
-        ) << "Expect " << " remains the same as no NANs";
+    EXPECT_PRED2(
+            Series::equal,
+            Series(),
+            Series().fillna()
+    ) << "Expect " << " empty array";
 
-        EXPECT_PRED2(
-                Series::equal,
-                Series(),
-                Series().dropna()
-        ) << "Expect " << " empty array";
+}
 
-        EXPECT_PRED2(
+TEST(Series, dropna) {
+    EXPECT_PRED2(
+            Series::equal,
+            Series({1, 3, 5}, {1, 3, 5}),
+            Series({1, NAN, 3, NAN, 5}, {1, 2, 3, 4, 5}).dropna()
+    ) << "Expect " << "drop NANs so indices only contains finite elements";
+
+    EXPECT_PRED2(
+            Series::equal,
+            Series({1, 2, 3, 4, 5}, {1, 2, 3, 4, 5}),
+            Series({1, 2, 3, 4, 5}, {1, 2, 3, 4, 5}).dropna()
+    ) << "Expect " << " remains the same as no NANs";
+
+    EXPECT_PRED2(
+            Series::equal,
+            Series(),
+            Series().dropna()
+    ) << "Expect " << " empty array";
+
+    EXPECT_PRED2(
             Series::equal,
             Series({1, arma::datum::inf, 3}, {1, 2, 4}),
             Series({1, arma::datum::inf, NAN, 3}, {1, 2, 3, 4}).dropna()
-        ) << "Expect " << " drops NA and preserves inf";
-    }
+    ) << "Expect " << " drops NA and preserves inf";
+}
 
-    TEST(Series, clipTest) {
-        EXPECT_PRED2(
-                Series::equal,
-                Series(arma::vec({}), arma::vec({})).clip(0, 1),
-                Series(arma::vec({}), arma::vec({}))
-        )  << "Expect " << "empty Series";
+TEST(Series, clipTest) {
+    EXPECT_PRED2(
+            Series::equal,
+            Series(arma::vec({}), arma::vec({})).clip(0, 1),
+            Series(arma::vec({}), arma::vec({}))
+    ) << "Expect " << "empty Series";
 
-        EXPECT_PRED2(
-                Series::equal,
-                Series(arma::vec({1, 2, 3, 4}), arma::vec({1, 2, 3, 4})).clip(2, 3),
-                Series(arma::vec({2, 2, 3, 3}), arma::vec({1, 2, 3, 4}))
-        ) << "Expect " << "indices clipped to 2-3";
+    EXPECT_PRED2(
+            Series::equal,
+            Series(arma::vec({1, 2, 3, 4}), arma::vec({1, 2, 3, 4})).clip(2, 3),
+            Series(arma::vec({2, 2, 3, 3}), arma::vec({1, 2, 3, 4}))
+    ) << "Expect " << "indices clipped to 2-3";
 
-        EXPECT_PRED2(
-                Series::equal,
-                Series(arma::vec({1, 2, 3, 4}), arma::vec({1, 2, 3, 4})).clip(0, 1),
-                Series(arma::vec({1, 1, 1, 1}), arma::vec({1, 2, 3, 4}))
-        ) << "Expect " << "indices clipped to 2-3";
-    }
+    EXPECT_PRED2(
+            Series::equal,
+            Series(arma::vec({1, 2, 3, 4}), arma::vec({1, 2, 3, 4})).clip(0, 1),
+            Series(arma::vec({1, 1, 1, 1}), arma::vec({1, 2, 3, 4}))
+    ) << "Expect " << "indices clipped to 2-3";
+}
 
-    TEST(Series, CountTest) {
-        EXPECT_EQ(Series(arma::vec({3, 4}), arma::vec({1, 2})).count(), 2)
-                            << "Expect " << "simple count() fixture result to be correct" << "";
+TEST(Series, CountTest) {
+    EXPECT_EQ(Series(arma::vec({3, 4}), arma::vec({1, 2})).count(), 2)
+                        << "Expect " << "simple count() fixture result to be correct" << "";
 
-        EXPECT_EQ(Series().count(), 0) << "Expect " << "empty series count() should be 0" << "";
+    EXPECT_EQ(Series().count(), 0) << "Expect " << "empty series count() should be 0" << "";
 
-        EXPECT_EQ(Series(arma::vec({3, NAN, 4}), arma::vec({1, 2, 3})).count(), 2)
-                            << "Expect " << "simple count() fixture result with NAN to be correct, ignoring NANs" << "";
+    EXPECT_EQ(Series(arma::vec({3, NAN, 4}), arma::vec({1, 2, 3})).count(), 2)
+                        << "Expect " << "simple count() fixture result with NAN to be correct, ignoring NANs" << "";
 
 
-    }
+}
 
-    TEST(Series, SumTest) {
-        EXPECT_EQ(Series(arma::vec({3, 4}), arma::vec({1, 2})).sum(), 7)
-                            << "Expect " << "simple sum() fixture result to be correct" << "";
+TEST(Series, SumTest) {
+    EXPECT_EQ(Series(arma::vec({3, 4}), arma::vec({1, 2})).sum(), 7)
+                        << "Expect " << "simple sum() fixture result to be correct" << "";
 
-        ASSERT_TRUE(std::isnan(Series(arma::vec({}), arma::vec({})).sum()))
-                                    << "Expect " << "empty series sum() should be NAN" << "";
+    ASSERT_TRUE(std::isnan(Series(arma::vec({}), arma::vec({})).sum()))
+                                << "Expect " << "empty series sum() should be NAN" << "";
 
-        EXPECT_EQ(Series(arma::vec({3, NAN, 4}), arma::vec({1, 2, 3})).sum(), 7)
-                            << "Expect " << "simple sum() fixture result with NAN to be correct, ignoring NANs" << "";
+    EXPECT_EQ(Series(arma::vec({3, NAN, 4}), arma::vec({1, 2, 3})).sum(), 7)
+                        << "Expect " << "simple sum() fixture result with NAN to be correct, ignoring NANs" << "";
 
 
-    }
+}
 
-    TEST(Series, MeanTest) {
-        EXPECT_EQ(Series(arma::vec({3, 4}), arma::vec({1, 2})).mean(), 3.5)
-                            << "Expect " << "simple mean() fixture result to be correct" << "";
+TEST(Series, MeanTest) {
+    EXPECT_EQ(Series(arma::vec({3, 4}), arma::vec({1, 2})).mean(), 3.5)
+                        << "Expect " << "simple mean() fixture result to be correct" << "";
 
-        ASSERT_TRUE(std::isnan(Series(arma::vec({}), arma::vec({})).mean()))
-                                    << "Expect " << "empty series mean() should be NAN" << "";
-
-        EXPECT_EQ(Series(arma::vec({3, NAN, 4}), arma::vec({1, 2, 3})).mean(), 3.5)
-                            << "Expect " << "simple mean() fixture result with NAN to be correct, ignoring NANs" << "";
-
-
-    }
-
-    TEST(Series, StdTest) {
-        auto root_2 = std::pow(2, .5);
-        EXPECT_FLOAT_EQ(Series(arma::vec({3, 4}), arma::vec({1, 2})).std(), 1 / root_2)
-                            << "Expect " << "simple std() fixture result to be correct" << "";
-
-        EXPECT_FLOAT_EQ(Series(arma::vec({3, 4}), arma::vec({1, 2})).std(0), 0.5)
-                            << "Expect " << "simple std() fixture result to be correct" << "";
-
-        ASSERT_TRUE(std::isnan(Series(arma::vec({}), arma::vec({})).std()))
-                                    << "Expect " << "empty series std() should be NAN" << "";
-
-        ASSERT_TRUE(std::isnan(Series(arma::vec({3}), arma::vec({1})).std()))
-                                    << "Expect " << "Series with 1 element std() should be NAN";
-
-        EXPECT_FLOAT_EQ(Series(arma::vec({3, NAN, 4}), arma::vec({1, 2, 3})).std(), 1 / root_2)
-                            << "Expect " << "simple std() fixture result with NAN to be correct, ignoring NANs" << "";
-
-
-    }
-
-    TEST(Series, operator__add) {
-        EXPECT_PRED2(
-                Series::equal,
-                Series() + 1,
-                Series()
-        ) << "Expect " << "empty Series stays empty";
-
-        EXPECT_PRED2(
-                Series::equal,
-                Series({3, 4}, {1, 2}) + 1,
-                Series({4, 5}, {1, 2})
-        ) << "Expect " << "adding 1 increases the values, not the index";
-
-        EXPECT_PRED2(
-                Series::equal,
-                Series({3, 4, arma::datum::nan}, {1, 2, 3}) + 1,
-                Series({4, 5, arma::datum::nan}, {1, 2, 3})
-        ) << "Expect " << "adding 1 increases the values, not the index, and ignores nan";
-
-        EXPECT_PRED2(
-                Series::equal,
-                Series({3, 4, 2, arma::datum::nan}, {1, 2, 3, 4}) +
-                Series({3, -5, arma::datum::nan, arma::datum::nan}, {1, 2, 3, 4}),
-                Series({6, -1, arma::datum::nan, arma::datum::nan}, {1, 2, 3, 4})
-        ) << "Expect " << "adding positive and negative values works and nan results in nan";
-    }
-
-
-    TEST(Series, operator__subtract) {
-        EXPECT_PRED2(
-                Series::equal,
-                Series() - 1,
-                Series()
-        ) << "Expect " << "empty Series stays empty";
-
-        EXPECT_PRED2(
-                Series::equal,
-                Series({3, 4}, {1, 2}) - 1,
-                Series({2, 3}, {1, 2})
-        ) << "Expect " << "adding 1 increases the values, not the index";
-
-        EXPECT_PRED2(
-                Series::equal,
-                Series({3, 4, arma::datum::nan}, {1, 2, 3}) - 1,
-                Series({2, 3, arma::datum::nan}, {1, 2, 3})
-        ) << "Expect " << "adding 1 increases the values, not the index, and ignores nan";
-
-        EXPECT_PRED2(
-                Series::equal,
-                Series({-3, 4, 2, arma::datum::nan}, {1, 2, 3, 4}) -
-                Series({3, -5, arma::datum::nan, arma::datum::nan}, {1, 2, 3, 4}),
-                Series({-6, 9, arma::datum::nan, arma::datum::nan}, {1, 2, 3, 4})
-        ) << "Expect " << "subtracting positive and negative values works and nan results in nan";
-    }
-
-
-    TEST(Series, operator__multiply) {
-        EXPECT_PRED2(
-                Series::equal,
-                Series() * 2,
-                Series()
-        ) << "Expect " << "empty Series stays empty";
-
-        EXPECT_PRED2(
-                Series::equal,
-                Series({3, 4}, {1, 2}) * 2,
-                Series({6, 8}, {1, 2})
-        ) << "Expect " << "multiplying by 2 changes the values, not the index";
-
-        EXPECT_PRED2(
-                Series::equal,
-                Series({3, 4, arma::datum::nan}, {1, 2, 3}) * 2,
-                Series({6, 8, arma::datum::nan}, {1, 2, 3})
-        ) << "Expect " << "multiplying by 2 changes the values, not the index, and ignores nan";
-
-        EXPECT_PRED2(
-                Series::equal,
-                Series({-3, 4, 2, arma::datum::nan}, {1, 2, 3, 4}) *
-                Series({3, -5, arma::datum::nan, arma::datum::nan}, {1, 2, 3, 4}),
-                Series({-9, -20, arma::datum::nan, arma::datum::nan}, {1, 2, 3, 4})
-        ) << "Expect " << "multiplying positive and negative values works and nan results in nan";
-    }
-
-
-    TEST(Series, operator__eq) {
-        EXPECT_PRED2(
-                polars::SeriesMask::equal,
-                Series() == Series(),
-                polars::SeriesMask()
-        ) << "Expect " << "empty Series stays empty";
-
-        EXPECT_PRED2(
-                polars::SeriesMask::equal,
-                Series({0, 1, 2, NAN}, {1, 2, 3, 4}) ==
-                Series({0, 1, 3, NAN}, {1, 2, 3, 4}),
-                polars::SeriesMask({1, 1, 0, 0}, {1, 2, 3, 4})
-        ) << "Expect " << "matching should match, but NAN != NAN for the elementwise operator";
-
-        EXPECT_PRED2(
-                polars::SeriesMask::equal,
-                Series() == 1,
-                polars::SeriesMask()
-        ) << "Expect " << "empty Series stays empty";
-
-        EXPECT_PRED2(
-                polars::SeriesMask::equal,
-                Series({0, 1.99, 2, 1 + 1, NAN}, {1, 2, 3, 4, 5}) == 2,
-                polars::SeriesMask({0, 0, 1, 1, 0}, {1, 2, 3, 4, 5})
-        ) << "Expect " << "matching should match, but NAN != NAN for the elementwise operator";
-    }
-
-
-    TEST(Series, operator__ne) {
-        EXPECT_PRED2(
-                polars::SeriesMask::equal,
-                Series() != 1,
-                polars::SeriesMask()
-        ) << "Expect " << "empty Series stays empty";
-
-        EXPECT_PRED2(
-                polars::SeriesMask::equal,
-                Series({0, 1.99, 2, 1 + 1, NAN}, {1, 2, 3, 4, 5}) != 2,
-                polars::SeriesMask({1, 1, 0, 0, 0}, {1, 2, 3, 4, 5})
-        ) << "Expect " << "matching should match, but NAN != NAN for the elementwise operator";
-    }
-
-    TEST(Series, operator__gt) {
-        EXPECT_PRED2(
-                polars::SeriesMask::equal,
-                Series() > Series(),
-                polars::SeriesMask()
-        ) << "Expect " << "empty Series stays empty";
-
-
-        EXPECT_PRED2(
-                polars::SeriesMask::equal,
-                Series({0, -1, 3, NAN}, {1, 2, 3, 4}) >
-                Series({0, -2, 2, NAN}, {1, 2, 3, 4}),
-                polars::SeriesMask({0, 1, 1, 0}, {1, 2, 3, 4})
-        ) << "Expect " << "> should work as per pair, including NAN != NAN";
-
-        EXPECT_PRED2(
-                polars::SeriesMask::equal,
-                Series({0, -1, 3, NAN}, {1, 2, 3, 4}) >= 0,
-                polars::SeriesMask({1, 0, 1, 0}, {1, 2, 3, 4})
-        ) << "Expect " << ">= should work per item, including NAN != NAN";
-    }
-
-    TEST(Series, operator__lt) {
-        EXPECT_PRED2(
-                polars::SeriesMask::equal,
-                Series() < Series(),
-                polars::SeriesMask()
-        ) << "Expect " << "empty Series stays empty";
-
-
-        EXPECT_PRED2(
-                polars::SeriesMask::equal,
-                Series({0, -2, 2, NAN}, {1, 2, 3, 4}) <
-                Series({0, -1, 3, NAN}, {1, 2, 3, 4}),
-                polars::SeriesMask({0, 1, 1, 0}, {1, 2, 3, 4})
-        ) << "Expect " << "> should work as per pair, including NAN != NAN";
-
-        EXPECT_PRED2(
-                polars::SeriesMask::equal,
-                Series({0, -1, 3, NAN}, {1, 2, 3, 4}) <= 0,
-                polars::SeriesMask({1, 1, 0, 0}, {1, 2, 3, 4})
-        ) << "Expect " << "<= should work per item, including NAN != NAN";
-    }
-
-
-    TEST(Series, apply){
-        EXPECT_PRED2(
-             Series::equal,
-             Series({1., 2., 3.}, {1, 2, 3}),
-             Series({1., 2., 3.}, {1, 2, 3}).apply(abs)
-        ) << "Expect " << " should remain ideantical";
-
-        EXPECT_PRED2(
-             Series::equal,
-             Series({1., 2., 3.}, {1, 2, 3}),
-             Series({-1., -2., -3.}, {1, 2, 3}).apply(abs)
-        ) << "Expect " << " should flip signs";
-
-        EXPECT_PRED2(
-             Series::equal,
-             Series({2.7182818284590451, 7.3890560989306504, 20.085536923187668}, {1, 2, 3}),
-             Series({1., 2., 3.}, {1, 2, 3}).apply(exp)
-        ) << "Expect " << " should apply exponential";
-
-        EXPECT_PRED2(
-             Series::equal,
-             Series({0, 0.19, 1.9, 1.9}, {1, 2, 3, 4}).apply(exp),
-             Series({1., 1.2092495976572515, 6.6858944422792685, 6.6858944422792685}, {1, 2, 3, 4})
-        ) << "Expect " << " should apply exponential";
-
-    }
-
-    TEST(Series, quantile){
-
-        EXPECT_TRUE(std::isnan(Series().quantile())) << "Expect" << " NAN for empty array";
-
-        EXPECT_EQ(Series({1}, {1}).quantile(1), 1) << "Expect" << " one";
-
-        EXPECT_EQ(Series({1, 2, 3}, {1, 2, 3}).quantile(), 2) << "Expect" << " median as default";
-
-        EXPECT_FLOAT_EQ(Series({0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}).quantile(0.3), 2.7) << "Expect" << " 0.3 quantile";
-
-    }
-
-    TEST(Series, iloc){
-
-        auto indices = arma::uvec{1, 2};
-
-        EXPECT_PRED2(
-                Series::equal,
-                Series({20, 40, 34, 10}, {1, 2, 3, 4}).iloc(indices),
-                Series({40, 34}, {2, 3})) << "Expect " << "subset including specified indices to be retrieved";
-
-
-        EXPECT_EQ(
-                Series({1, 2, 3, 4}, {1, 2, 3, 4}).iloc(2),
+    ASSERT_TRUE(std::isnan(Series(arma::vec({}), arma::vec({})).mean()))
+                                << "Expect " << "empty series mean() should be NAN" << "";
+
+    EXPECT_EQ(Series(arma::vec({3, NAN, 4}), arma::vec({1, 2, 3})).mean(), 3.5)
+                        << "Expect " << "simple mean() fixture result with NAN to be correct, ignoring NANs" << "";
+
+
+}
+
+TEST(Series, StdTest) {
+    auto root_2 = std::pow(2, .5);
+    EXPECT_FLOAT_EQ(Series(arma::vec({3, 4}), arma::vec({1, 2})).std(), 1 / root_2)
+                        << "Expect " << "simple std() fixture result to be correct" << "";
+
+    EXPECT_FLOAT_EQ(Series(arma::vec({3, 4}), arma::vec({1, 2})).std(0), 0.5)
+                        << "Expect " << "simple std() fixture result to be correct" << "";
+
+    ASSERT_TRUE(std::isnan(Series(arma::vec({}), arma::vec({})).std()))
+                                << "Expect " << "empty series std() should be NAN" << "";
+
+    ASSERT_TRUE(std::isnan(Series(arma::vec({3}), arma::vec({1})).std()))
+                                << "Expect " << "Series with 1 element std() should be NAN";
+
+    EXPECT_FLOAT_EQ(Series(arma::vec({3, NAN, 4}), arma::vec({1, 2, 3})).std(), 1 / root_2)
+                        << "Expect " << "simple std() fixture result with NAN to be correct, ignoring NANs" << "";
+
+
+}
+
+TEST(Series, operator__add) {
+    EXPECT_PRED2(
+            Series::equal,
+            Series() + 1,
+            Series()
+    ) << "Expect " << "empty Series stays empty";
+
+    EXPECT_PRED2(
+            Series::equal,
+            Series({3, 4}, {1, 2}) + 1,
+            Series({4, 5}, {1, 2})
+    ) << "Expect " << "adding 1 increases the values, not the index";
+
+    EXPECT_PRED2(
+            Series::equal,
+            Series({3, 4, arma::datum::nan}, {1, 2, 3}) + 1,
+            Series({4, 5, arma::datum::nan}, {1, 2, 3})
+    ) << "Expect " << "adding 1 increases the values, not the index, and ignores nan";
+
+    EXPECT_PRED2(
+            Series::equal,
+            Series({3, 4, 2, arma::datum::nan}, {1, 2, 3, 4}) +
+            Series({3, -5, arma::datum::nan, arma::datum::nan}, {1, 2, 3, 4}),
+            Series({6, -1, arma::datum::nan, arma::datum::nan}, {1, 2, 3, 4})
+    ) << "Expect " << "adding positive and negative values works and nan results in nan";
+}
+
+
+TEST(Series, operator__subtract) {
+    EXPECT_PRED2(
+            Series::equal,
+            Series() - 1,
+            Series()
+    ) << "Expect " << "empty Series stays empty";
+
+    EXPECT_PRED2(
+            Series::equal,
+            Series({3, 4}, {1, 2}) - 1,
+            Series({2, 3}, {1, 2})
+    ) << "Expect " << "adding 1 increases the values, not the index";
+
+    EXPECT_PRED2(
+            Series::equal,
+            Series({3, 4, arma::datum::nan}, {1, 2, 3}) - 1,
+            Series({2, 3, arma::datum::nan}, {1, 2, 3})
+    ) << "Expect " << "adding 1 increases the values, not the index, and ignores nan";
+
+    EXPECT_PRED2(
+            Series::equal,
+            Series({-3, 4, 2, arma::datum::nan}, {1, 2, 3, 4}) -
+            Series({3, -5, arma::datum::nan, arma::datum::nan}, {1, 2, 3, 4}),
+            Series({-6, 9, arma::datum::nan, arma::datum::nan}, {1, 2, 3, 4})
+    ) << "Expect " << "subtracting positive and negative values works and nan results in nan";
+}
+
+
+TEST(Series, operator__multiply) {
+    EXPECT_PRED2(
+            Series::equal,
+            Series() * 2,
+            Series()
+    ) << "Expect " << "empty Series stays empty";
+
+    EXPECT_PRED2(
+            Series::equal,
+            Series({3, 4}, {1, 2}) * 2,
+            Series({6, 8}, {1, 2})
+    ) << "Expect " << "multiplying by 2 changes the values, not the index";
+
+    EXPECT_PRED2(
+            Series::equal,
+            Series({3, 4, arma::datum::nan}, {1, 2, 3}) * 2,
+            Series({6, 8, arma::datum::nan}, {1, 2, 3})
+    ) << "Expect " << "multiplying by 2 changes the values, not the index, and ignores nan";
+
+    EXPECT_PRED2(
+            Series::equal,
+            Series({-3, 4, 2, arma::datum::nan}, {1, 2, 3, 4}) *
+            Series({3, -5, arma::datum::nan, arma::datum::nan}, {1, 2, 3, 4}),
+            Series({-9, -20, arma::datum::nan, arma::datum::nan}, {1, 2, 3, 4})
+    ) << "Expect " << "multiplying positive and negative values works and nan results in nan";
+}
+
+
+TEST(Series, operator__eq) {
+    EXPECT_PRED2(
+            polars::SeriesMask::equal,
+            Series() == Series(),
+            polars::SeriesMask()
+    ) << "Expect " << "empty Series stays empty";
+
+    EXPECT_PRED2(
+            polars::SeriesMask::equal,
+            Series({0, 1, 2, NAN}, {1, 2, 3, 4}) ==
+            Series({0, 1, 3, NAN}, {1, 2, 3, 4}),
+            polars::SeriesMask({1, 1, 0, 0}, {1, 2, 3, 4})
+    ) << "Expect " << "matching should match, but NAN != NAN for the elementwise operator";
+
+    EXPECT_PRED2(
+            polars::SeriesMask::equal,
+            Series() == 1,
+            polars::SeriesMask()
+    ) << "Expect " << "empty Series stays empty";
+
+    EXPECT_PRED2(
+            polars::SeriesMask::equal,
+            Series({0, 1.99, 2, 1 + 1, NAN}, {1, 2, 3, 4, 5}) == 2,
+            polars::SeriesMask({0, 0, 1, 1, 0}, {1, 2, 3, 4, 5})
+    ) << "Expect " << "matching should match, but NAN != NAN for the elementwise operator";
+}
+
+
+TEST(Series, operator__ne) {
+    EXPECT_PRED2(
+            polars::SeriesMask::equal,
+            Series() != 1,
+            polars::SeriesMask()
+    ) << "Expect " << "empty Series stays empty";
+
+    EXPECT_PRED2(
+            polars::SeriesMask::equal,
+            Series({0, 1.99, 2, 1 + 1, NAN}, {1, 2, 3, 4, 5}) != 2,
+            polars::SeriesMask({1, 1, 0, 0, 0}, {1, 2, 3, 4, 5})
+    ) << "Expect " << "matching should match, but NAN != NAN for the elementwise operator";
+}
+
+TEST(Series, operator__gt) {
+    EXPECT_PRED2(
+            polars::SeriesMask::equal,
+            Series() > Series(),
+            polars::SeriesMask()
+    ) << "Expect " << "empty Series stays empty";
+
+
+    EXPECT_PRED2(
+            polars::SeriesMask::equal,
+            Series({0, -1, 3, NAN}, {1, 2, 3, 4}) >
+            Series({0, -2, 2, NAN}, {1, 2, 3, 4}),
+            polars::SeriesMask({0, 1, 1, 0}, {1, 2, 3, 4})
+    ) << "Expect " << "> should work as per pair, including NAN != NAN";
+
+    EXPECT_PRED2(
+            polars::SeriesMask::equal,
+            Series({0, -1, 3, NAN}, {1, 2, 3, 4}) >= 0,
+            polars::SeriesMask({1, 0, 1, 0}, {1, 2, 3, 4})
+    ) << "Expect " << ">= should work per item, including NAN != NAN";
+}
+
+TEST(Series, operator__lt) {
+    EXPECT_PRED2(
+            polars::SeriesMask::equal,
+            Series() < Series(),
+            polars::SeriesMask()
+    ) << "Expect " << "empty Series stays empty";
+
+
+    EXPECT_PRED2(
+            polars::SeriesMask::equal,
+            Series({0, -2, 2, NAN}, {1, 2, 3, 4}) <
+            Series({0, -1, 3, NAN}, {1, 2, 3, 4}),
+            polars::SeriesMask({0, 1, 1, 0}, {1, 2, 3, 4})
+    ) << "Expect " << "> should work as per pair, including NAN != NAN";
+
+    EXPECT_PRED2(
+            polars::SeriesMask::equal,
+            Series({0, -1, 3, NAN}, {1, 2, 3, 4}) <= 0,
+            polars::SeriesMask({1, 1, 0, 0}, {1, 2, 3, 4})
+    ) << "Expect " << "<= should work per item, including NAN != NAN";
+}
+
+
+TEST(Series, apply) {
+    EXPECT_PRED2(
+            Series::equal,
+            Series({1., 2., 3.}, {1, 2, 3}),
+            Series({1., 2., 3.}, {1, 2, 3}).apply(abs)
+    ) << "Expect " << " should remain ideantical";
+
+    EXPECT_PRED2(
+            Series::equal,
+            Series({1., 2., 3.}, {1, 2, 3}),
+            Series({-1., -2., -3.}, {1, 2, 3}).apply(abs)
+    ) << "Expect " << " should flip signs";
+
+    EXPECT_PRED2(
+            Series::equal,
+            Series({2.7182818284590451, 7.3890560989306504, 20.085536923187668}, {1, 2, 3}),
+            Series({1., 2., 3.}, {1, 2, 3}).apply(exp)
+    ) << "Expect " << " should apply exponential";
+
+    EXPECT_PRED2(
+            Series::equal,
+            Series({0, 0.19, 1.9, 1.9}, {1, 2, 3, 4}).apply(exp),
+            Series({1., 1.2092495976572515, 6.6858944422792685, 6.6858944422792685}, {1, 2, 3, 4})
+    ) << "Expect " << " should apply exponential";
+
+}
+
+TEST(Series, quantile) {
+
+    EXPECT_TRUE(std::isnan(Series().quantile())) << "Expect" << " NAN for empty array";
+
+    EXPECT_EQ(Series({1}, {1}).quantile(1), 1) << "Expect" << " one";
+
+    EXPECT_EQ(Series({1, 2, 3}, {1, 2, 3}).quantile(), 2) << "Expect" << " median as default";
+
+    EXPECT_FLOAT_EQ(Series({0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}).quantile(0.3), 2.7)
+                        << "Expect" << " 0.3 quantile";
+
+}
+
+TEST(Series, iloc) {
+
+    auto indices = arma::uvec{1, 2};
+
+    EXPECT_PRED2(
+            Series::equal,
+            Series({20, 40, 34, 10}, {1, 2, 3, 4}).iloc(indices),
+            Series({40, 34}, {2, 3})) << "Expect " << "subset including specified indices to be retrieved";
+
+
+    EXPECT_EQ(
+            Series({1, 2, 3, 4}, {1, 2, 3, 4}).iloc(2),
             3
-        ) << "Expect " << " element 3 to be retrieved";
+    ) << "Expect " << " element 3 to be retrieved";
 
-    }
+}
 
-    TEST(Series, loc){
+TEST(Series, loc) {
 
-        auto labels = arma::vec{3, 4};
-        EXPECT_PRED2(
-                Series::equal,
-                Series({2, 3, 4, 10}, {3, 4, 5, 6}).loc(labels),
-                Series({2, 3}, {3, 4})
-        ) << "Expect " << " indices values retrieved by label";
+    auto labels = arma::vec{3, 4};
+    EXPECT_PRED2(
+            Series::equal,
+            Series({2, 3, 4, 10}, {3, 4, 5, 6}).loc(labels),
+            Series({2, 3}, {3, 4})
+    ) << "Expect " << " indices values retrieved by label";
 
-        auto non_valid_labels = arma::vec{30, 40};
-        EXPECT_PRED2(
+    auto non_valid_labels = arma::vec{30, 40};
+    EXPECT_PRED2(
             Series::equal,
             Series({30, 40, 53, 32}, {3, 4, 5, 6}).loc(non_valid_labels),
             Series()
-        ) << "Expect " << " empty indices since no records match labels";
+    ) << "Expect " << " empty indices since no records match labels";
 
-        EXPECT_PRED2(
-                Series::equal,
-                Series({10, 30, 40, 20}, {3, 4, 5, 6}).loc(4),
-                Series({30}, {4})
-        ) << "Expect " << "indices values retrieved by label";
+    EXPECT_PRED2(
+            Series::equal,
+            Series({10, 30, 40, 20}, {3, 4, 5, 6}).loc(4),
+            Series({30}, {4})
+    ) << "Expect " << "indices values retrieved by label";
 
-        EXPECT_PRED2(
-                Series::equal,
-                Series({10, 30, 40, 20}, {3, 4, 5, 6}).loc(8),
-                Series()
-        ) << "Expect " << "empty indices since no records match label";
-    }
+    EXPECT_PRED2(
+            Series::equal,
+            Series({10, 30, 40, 20}, {3, 4, 5, 6}).loc(8),
+            Series()
+    ) << "Expect " << "empty indices since no records match label";
+}
 
-    TEST(Series, index_as_series){
-        EXPECT_PRED2(
-                Series::equal,
-                Series().index_as_series(),
-                Series()
-        ) << "Expect " << " empty series";
+TEST(Series, index_as_series) {
+    EXPECT_PRED2(
+            Series::equal,
+            Series().index_as_series(),
+            Series()
+    ) << "Expect " << " empty series";
 
-        EXPECT_PRED2(
+    EXPECT_PRED2(
             Series::equal,
             Series({4, 5, 6, 3}, {1, 2, 3, 4}).index_as_series(),
             Series({1, 2, 3, 4}, {1, 2, 3, 4})
-        ) << "Expect " << "index as a series";
-    }
+    ) << "Expect " << "index as a series";
+}
 
-    TEST(Series, from_vect){
+TEST(Series, from_vect) {
 
-        std::vector<double> z = {1, 2, 3, 4};
+    std::vector<double> z = {1, 2, 3, 4};
 
-        EXPECT_PRED2(
+    EXPECT_PRED2(
             Series::equal,
             Series::from_vect(z, z),
             Series({1, 2, 3, 4}, {1, 2, 3, 4})
-        ) << "Expect " << "identical indices due to passing vectors";
+    ) << "Expect " << "identical indices due to passing vectors";
 
-        std::vector<double> y = {};
-        EXPECT_PRED2(
-                Series::equal,
-                Series::from_vect(y, y),
-                Series({}, {})
-        ) << "Expect " << "identical indices due to passing vectors";
+    std::vector<double> y = {};
+    EXPECT_PRED2(
+            Series::equal,
+            Series::from_vect(y, y),
+            Series({}, {})
+    ) << "Expect " << "identical indices due to passing vectors";
+}
+
+TEST(Series, to_map) {
+
+    Series z = Series({10, 20, 30, 40}, {1, 2, 3, 4});
+
+    int i = 0;
+    for (auto &pair : z.to_map()) {
+        auto key = pair.first;
+        auto value = pair.second;
+
+        EXPECT_EQ(key, z.index()[i]);
+        EXPECT_EQ(value, z.values()[i]);
+        i++;
     }
 
-    TEST(Series, to_map){
+    EXPECT_TRUE(Series().to_map().empty());
+}
 
-        Series z = Series({10, 20, 30, 40}, {1, 2, 3, 4});
+TEST(Series, head) {
 
-        int i = 0;
-        for (auto& pair : z.to_map()) {
-            auto key = pair.first;
-            auto value = pair.second;
+    Series z = Series({10, 20, 30, 40, 50, 60}, {1, 2, 3, 4, 5, 6});
 
-            EXPECT_EQ(key, z.index()[i]);
-            EXPECT_EQ(value, z.values()[i]);
-            i++;
-        }
+    EXPECT_PRED2(
+            Series::equal,
+            z.head(),
+            Series({10, 20, 30, 40, 50}, {1, 2, 3, 4, 5})
+    );
 
-        EXPECT_TRUE(Series().to_map().empty());
-    }
+    EXPECT_PRED2(
+            Series::equal,
+            z.head(3),
+            Series({10, 20, 30}, {1, 2, 3,})
+    );
 
-    TEST(Series, head){
+    EXPECT_PRED2(
+            Series::equal,
+            z.head(0),
+            Series()
+    );
 
-        Series z = Series({10, 20, 30, 40, 50, 60}, {1, 2, 3, 4, 5, 6});
+    EXPECT_PRED2(
+            Series::equal,
+            z.head(10),
+            z
+    );
 
-        EXPECT_PRED2(
-                Series::equal,
-                z.head(),
-                Series({10, 20, 30, 40, 50}, {1, 2, 3, 4, 5})
-        );
+}
 
-        EXPECT_PRED2(
-                Series::equal,
-                z.head(3),
-                Series({10, 20, 30}, {1, 2, 3,})
-        );
+TEST(Series, tail) {
 
-        EXPECT_PRED2(
-                Series::equal,
-                z.head(0),
-                Series()
-        );
+    Series z = Series({10, 20, 30, 40, 50, 60}, {1, 2, 3, 4, 5, 6});
 
-        EXPECT_PRED2(
-                Series::equal,
-                z.head(10),
-                z
-        );
+    EXPECT_PRED2(
+            Series::equal,
+            z.tail(),
+            Series({20, 30, 40, 50, 60}, {2, 3, 4, 5, 6})
+    );
 
-    }
+    EXPECT_PRED2(
+            Series::equal,
+            z.tail(3),
+            Series({40, 50, 60}, {4, 5, 6})
+    );
 
-    TEST(Series, tail){
+    EXPECT_PRED2(
+            Series::equal,
+            z.tail(0),
+            Series()
+    );
 
-        Series z = Series({10, 20, 30, 40, 50, 60}, {1, 2, 3, 4, 5, 6});
-
-        EXPECT_PRED2(
-                Series::equal,
-                z.tail(),
-                Series({20, 30, 40, 50, 60}, {2, 3, 4, 5, 6})
-        );
-
-        EXPECT_PRED2(
-                Series::equal,
-                z.tail(3),
-                Series({40, 50, 60}, {4, 5, 6})
-        );
-
-        EXPECT_PRED2(
-                Series::equal,
-                z.tail(0),
-                Series()
-        );
-
-        EXPECT_PRED2(
-                Series::equal,
-                z.tail(10),
-                z
-        );
-    }
+    EXPECT_PRED2(
+            Series::equal,
+            z.tail(10),
+            z
+    );
+}
 
 } // namespace SeriesTests

--- a/tests/test_cpp/polars/TestTimeSeries.cpp
+++ b/tests/test_cpp/polars/TestTimeSeries.cpp
@@ -13,243 +13,243 @@
 
 
 namespace TimeSeriesTests {
-    using namespace polars;
-    using namespace std::chrono;
+using namespace polars;
+using namespace std::chrono;
 
-    TEST(TimeSeries, constructor) {
+TEST(TimeSeries, constructor) {
 
-        using TimePoint = time_point<system_clock, milliseconds>;
+    using TimePoint = time_point<system_clock, milliseconds>;
 
-        time_t t1 = 1525971600;  // 10th May 2018 6pm BST
-        time_t t2 = 1525971780;
+    time_t t1 = 1525971600;  // 10th May 2018 6pm BST
+    time_t t2 = 1525971780;
 
-        TimePoint t1_p{duration_cast<milliseconds>(polars::unix_epoch_seconds(t1))};
-        TimePoint t2_p{duration_cast<milliseconds>(polars::unix_epoch_seconds(t2))};
+    TimePoint t1_p{duration_cast<milliseconds>(polars::unix_epoch_seconds(t1))};
+    TimePoint t2_p{duration_cast<milliseconds>(polars::unix_epoch_seconds(t2))};
 
-        std::vector<TimePoint> tpoints = {t1_p, t2_p};
-        arma::vec vals = {0.1, 0.2};
+    std::vector<TimePoint> tpoints = {t1_p, t2_p};
+    arma::vec vals = {0.1, 0.2};
 
-        EXPECT_PRED2(
-                polars::MillisecondsTimeSeries::equal,
-                polars::MillisecondsTimeSeries(),
-                polars::MillisecondsTimeSeries()
-        ) << "Expect " << "empty TimeSeries' match";
+    EXPECT_PRED2(
+            polars::MillisecondsTimeSeries::equal,
+            polars::MillisecondsTimeSeries(),
+            polars::MillisecondsTimeSeries()
+    ) << "Expect " << "empty TimeSeries' match";
 
-        auto ts = polars::MillisecondsTimeSeries(vals, tpoints);
+    auto ts = polars::MillisecondsTimeSeries(vals, tpoints);
 
-        EXPECT_PRED2(
-                polars::numc::equal_handling_nans,
-                ts.values(),
-                arma::vec({0.1, 0.2})
-        ) << "Expect " << "retrieves values of timeseries";
+    EXPECT_PRED2(
+            polars::numc::equal_handling_nans,
+            ts.values(),
+            arma::vec({0.1, 0.2})
+    ) << "Expect " << "retrieves values of timeseries";
 
-        EXPECT_PRED2(
-                polars::numc::equal_handling_nans,
-                ts.index(),
-                arma::vec({1525971600000, 1525971780000}) // in milliseconds
-        ) << "Expect " << " timestamps in milliseconds";
+    EXPECT_PRED2(
+            polars::numc::equal_handling_nans,
+            ts.index(),
+            arma::vec({1525971600000, 1525971780000}) // in milliseconds
+    ) << "Expect " << " timestamps in milliseconds";
 
-        // TODO deal with duplicate values in constructor one way or the other
+    // TODO deal with duplicate values in constructor one way or the other
+}
+
+TEST(TimeSeries, from_map) {
+    using TP = time_point<system_clock, seconds>;
+
+    EXPECT_PRED2(SecondsTimeSeries::equal, SecondsTimeSeries::from_map({}), SecondsTimeSeries());
+
+    EXPECT_PRED2(
+            SecondsTimeSeries::equal,
+            SecondsTimeSeries::from_map({{TP(1s), 3},
+                                         {TP(2s), 4}}),
+            SecondsTimeSeries({3, 4}, {TP(1s), TP(2s)})
+    );
+
+}
+
+TEST(TimeSeries, get_timestamps) {
+
+    using TimePoint = time_point<system_clock, seconds>;
+
+    time_t t = 1525971600;
+    TimePoint t_p{duration_cast<seconds>(polars::unix_epoch_seconds(t))};
+
+    time_t t2 = 1525971780;
+    TimePoint t2_p{duration_cast<seconds>(polars::unix_epoch_seconds(t2))};
+
+    std::vector<TimePoint> tpoints = {t_p, t2_p};
+    arma::vec timestamps = {(double) t, (double) t2};
+
+    // Build TimeSeries
+    polars::SecondsTimeSeries ts = polars::SecondsTimeSeries(arma::vec{1, 2}, tpoints);
+    std::vector<TimePoint> tstamps = ts.timestamps();
+
+    for (int i = 0; i < tstamps.size(); i++) {
+        EXPECT_EQ(tstamps[i].time_since_epoch().count(), timestamps[i]);
     }
 
-    TEST(TimeSeries, from_map) {
-        using TP = time_point<system_clock, seconds>;
+    // Case in which we pass an empty timeseries
+    polars::SecondsTimeSeries ts_empty = polars::SecondsTimeSeries();
+    std::vector<TimePoint> tstamps_empty = ts_empty.timestamps();
 
-        EXPECT_PRED2(SecondsTimeSeries::equal, SecondsTimeSeries::from_map({}), SecondsTimeSeries());
+    EXPECT_TRUE(tstamps_empty.empty()) << "Expect " << " true since timeseries is empty";
+};
 
-        EXPECT_PRED2(
-                SecondsTimeSeries::equal,
-                SecondsTimeSeries::from_map({{TP(1s), 3},
-                                             {TP(2s), 4}}),
-                SecondsTimeSeries({3, 4}, {TP(1s), TP(2s)})
-        );
+TEST(TimeSeries, to_timeseries_map) {
 
+    using TimePoint = time_point<system_clock, seconds>;
+
+    time_t t = 1525971600;
+    TimePoint t_p{duration_cast<seconds>(polars::unix_epoch_seconds(t))};
+
+    time_t t2 = 1525971780;
+    TimePoint t2_p{duration_cast<seconds>(polars::unix_epoch_seconds(t2))};
+
+    std::vector<TimePoint> tpoints = {t_p, t2_p};
+    arma::vec vals = {1, 2};
+
+    // Build TimeSeries
+    polars::SecondsTimeSeries ts = polars::SecondsTimeSeries(vals, tpoints);
+
+    std::map<TimePoint, double> ts_map = ts.to_timeseries_map();
+
+    int i = 0;
+    for (auto &pair : ts_map) {
+        auto key = pair.first;
+        auto value = pair.second;
+
+        EXPECT_EQ(key.time_since_epoch().count(), (double) ts.index()[i]);
+        EXPECT_EQ(value, ts.values()[i]);
+        i++;
     }
 
-    TEST(TimeSeries, get_timestamps) {
+    // Case in which we pass an empty timeseries
+    polars::SecondsTimeSeries ts_empty = polars::SecondsTimeSeries();
+    std::map<TimePoint, double> ts_empty_map = ts_empty.to_timeseries_map();
 
-        using TimePoint = time_point<system_clock, seconds>;
-
-        time_t t = 1525971600;
-        TimePoint t_p{duration_cast<seconds>(polars::unix_epoch_seconds(t))};
-
-        time_t t2 = 1525971780;
-        TimePoint t2_p{duration_cast<seconds>(polars::unix_epoch_seconds(t2))};
-
-        std::vector<TimePoint> tpoints = {t_p, t2_p};
-        arma::vec timestamps = {(double) t, (double) t2};
-
-        // Build TimeSeries
-        polars::SecondsTimeSeries ts = polars::SecondsTimeSeries(arma::vec{1, 2}, tpoints);
-        std::vector<TimePoint> tstamps = ts.timestamps();
-
-        for (int i = 0; i < tstamps.size(); i++) {
-            EXPECT_EQ(tstamps[i].time_since_epoch().count(), timestamps[i]);
-        }
-
-        // Case in which we pass an empty timeseries
-        polars::SecondsTimeSeries ts_empty = polars::SecondsTimeSeries();
-        std::vector<TimePoint> tstamps_empty = ts_empty.timestamps();
-
-        EXPECT_TRUE(tstamps_empty.empty()) << "Expect " << " true since timeseries is empty";
-    };
-
-    TEST(TimeSeries, to_timeseries_map) {
-
-        using TimePoint = time_point<system_clock, seconds>;
-
-        time_t t = 1525971600;
-        TimePoint t_p{duration_cast<seconds>(polars::unix_epoch_seconds(t))};
-
-        time_t t2 = 1525971780;
-        TimePoint t2_p{duration_cast<seconds>(polars::unix_epoch_seconds(t2))};
-
-        std::vector<TimePoint> tpoints = {t_p, t2_p};
-        arma::vec vals = {1, 2};
-
-        // Build TimeSeries
-        polars::SecondsTimeSeries ts = polars::SecondsTimeSeries(vals, tpoints);
-
-        std::map<TimePoint, double> ts_map = ts.to_timeseries_map();
-
-        int i = 0;
-        for (auto &pair : ts_map) {
-            auto key = pair.first;
-            auto value = pair.second;
-
-            EXPECT_EQ(key.time_since_epoch().count(), (double) ts.index()[i]);
-            EXPECT_EQ(value, ts.values()[i]);
-            i++;
-        }
-
-        // Case in which we pass an empty timeseries
-        polars::SecondsTimeSeries ts_empty = polars::SecondsTimeSeries();
-        std::map<TimePoint, double> ts_empty_map = ts_empty.to_timeseries_map();
-
-        EXPECT_TRUE(ts_empty_map.empty()) << "Expect " << " true since map is empty";
-    };
+    EXPECT_TRUE(ts_empty_map.empty()) << "Expect " << " true since map is empty";
+};
 
 
-    TEST(TimeSeries, loc) {
+TEST(TimeSeries, loc) {
 
-        using TimePoint = time_point<system_clock, minutes>;
+    using TimePoint = time_point<system_clock, minutes>;
 
-        time_t t1 = 1525971600;
-        time_t t2 = 1525971780;
-        time_t t3 = 1525971960;
+    time_t t1 = 1525971600;
+    time_t t2 = 1525971780;
+    time_t t3 = 1525971960;
 
-        TimePoint t1_p{duration_cast<minutes>(polars::unix_epoch_seconds(t1))};
-        TimePoint t2_p{duration_cast<minutes>(polars::unix_epoch_seconds(t2))};
-        TimePoint t3_p{duration_cast<minutes>(polars::unix_epoch_seconds(t3))};
+    TimePoint t1_p{duration_cast<minutes>(polars::unix_epoch_seconds(t1))};
+    TimePoint t2_p{duration_cast<minutes>(polars::unix_epoch_seconds(t2))};
+    TimePoint t3_p{duration_cast<minutes>(polars::unix_epoch_seconds(t3))};
 
-        std::vector<TimePoint> tpoints = {t1_p, t2_p, t3_p};
-        std::vector<TimePoint> index_labels = {t2_p, t3_p};
+    std::vector<TimePoint> tpoints = {t1_p, t2_p, t3_p};
+    std::vector<TimePoint> index_labels = {t2_p, t3_p};
 
-        arma::vec vals = {1, 2, 3};
+    arma::vec vals = {1, 2, 3};
 
-        // Build TimeSeries
-        polars::MinutesTimeSeries ts = polars::MinutesTimeSeries(vals, tpoints);
+    // Build TimeSeries
+    polars::MinutesTimeSeries ts = polars::MinutesTimeSeries(vals, tpoints);
 
-        // Index Labels
-        polars::MinutesTimeSeries ts_subset = ts.loc(index_labels);
+    // Index Labels
+    polars::MinutesTimeSeries ts_subset = ts.loc(index_labels);
 
-        EXPECT_PRED2(
-                polars::numc::equal_handling_nans,
-                ts_subset.values(),
-                arma::vec({2, 3})
-        ) << "Expect " << "subset of values corresponding to provided indices";
+    EXPECT_PRED2(
+            polars::numc::equal_handling_nans,
+            ts_subset.values(),
+            arma::vec({2, 3})
+    ) << "Expect " << "subset of values corresponding to provided indices";
 
-        // Case in which labels are not in the ts
-        std::vector<TimePoint> index_labels_empty = {};
-        polars::MinutesTimeSeries ts_empty = ts.loc(index_labels_empty);
+    // Case in which labels are not in the ts
+    std::vector<TimePoint> index_labels_empty = {};
+    polars::MinutesTimeSeries ts_empty = ts.loc(index_labels_empty);
 
-        EXPECT_TRUE(ts_empty.empty()) << "Expect " << " true since timeseries is empty";
-    }
+    EXPECT_TRUE(ts_empty.empty()) << "Expect " << " true since timeseries is empty";
+}
 
-    TEST(TimeSeries, prettyprint) {
+TEST(TimeSeries, prettyprint) {
 
-        // TODO: Add test for larger timeseries.
+    // TODO: Add test for larger timeseries.
 
-        std::stringstream out;
-        using TimePoint = time_point<system_clock, seconds>;
+    std::stringstream out;
+    using TimePoint = time_point<system_clock, seconds>;
 
-        time_t t = 1525971600;
-        TimePoint t_p{duration_cast<seconds>(polars::unix_epoch_seconds(t))};
+    time_t t = 1525971600;
+    TimePoint t_p{duration_cast<seconds>(polars::unix_epoch_seconds(t))};
 
-        time_t t2 = 1525971780;
-        TimePoint t2_p{duration_cast<seconds>(polars::unix_epoch_seconds(t2))};
+    time_t t2 = 1525971780;
+    TimePoint t2_p{duration_cast<seconds>(polars::unix_epoch_seconds(t2))};
 
-        std::vector<TimePoint> tpoints = {t_p, t2_p};
-        arma::vec vals = {1, 2};
+    std::vector<TimePoint> tpoints = {t_p, t2_p};
+    arma::vec vals = {1, 2};
 
-        // Build TimeSeries
-        polars::SecondsTimeSeries ts = polars::SecondsTimeSeries(vals, tpoints);
+    // Build TimeSeries
+    polars::SecondsTimeSeries ts = polars::SecondsTimeSeries(vals, tpoints);
 
-        // Check output
-        out << ts;
+    // Check output
+    out << ts;
 
-        EXPECT_EQ(out.str(),
-                  "Timeseries: \nTimestamp:\n2018 May 10 17:00:00 Value:\n1Timestamp:\n2018 May 10 17:03:00 Value:\n2");
+    EXPECT_EQ(out.str(),
+              "Timeseries: \nTimestamp:\n2018 May 10 17:00:00 Value:\n1Timestamp:\n2018 May 10 17:03:00 Value:\n2");
 
-    }
+}
 
-    TEST(TimeSeries, head_and_tail) {
-        // Method work as expected
-        using TimePoint = time_point<system_clock, seconds>;
+TEST(TimeSeries, head_and_tail) {
+    // Method work as expected
+    using TimePoint = time_point<system_clock, seconds>;
 
-        time_t t1 = 1525971600;
-        time_t t2 = 1525971780;
-        time_t t3 = 1525971960;
+    time_t t1 = 1525971600;
+    time_t t2 = 1525971780;
+    time_t t3 = 1525971960;
 
-        TimePoint t1_p{duration_cast<minutes>(polars::unix_epoch_seconds(t1))};
-        TimePoint t2_p{duration_cast<minutes>(polars::unix_epoch_seconds(t2))};
-        TimePoint t3_p{duration_cast<minutes>(polars::unix_epoch_seconds(t3))};
+    TimePoint t1_p{duration_cast<minutes>(polars::unix_epoch_seconds(t1))};
+    TimePoint t2_p{duration_cast<minutes>(polars::unix_epoch_seconds(t2))};
+    TimePoint t3_p{duration_cast<minutes>(polars::unix_epoch_seconds(t3))};
 
-        std::vector<TimePoint> tpoints = {t1_p, t2_p, t3_p};
-        arma::vec vals = {1, 2, 3};
+    std::vector<TimePoint> tpoints = {t1_p, t2_p, t3_p};
+    arma::vec vals = {1, 2, 3};
 
-        // Build TimeSeries
-        polars::SecondsTimeSeries ts = polars::SecondsTimeSeries(vals, tpoints);
+    // Build TimeSeries
+    polars::SecondsTimeSeries ts = polars::SecondsTimeSeries(vals, tpoints);
 
-        EXPECT_PRED2(
-                polars::TimeSeries<TimePoint>::equal,
-                ts.head(2),
-                polars::SecondsTimeSeries({1, 2}, {t1_p, t2_p})
-        );
+    EXPECT_PRED2(
+            polars::TimeSeries<TimePoint>::equal,
+            ts.head(2),
+            polars::SecondsTimeSeries({1, 2}, {t1_p, t2_p})
+    );
 
-        EXPECT_PRED2(
-                polars::TimeSeries<TimePoint>::equal,
-                ts.tail(2),
-                polars::SecondsTimeSeries({2, 3}, {t2_p, t3_p})
-        );
+    EXPECT_PRED2(
+            polars::TimeSeries<TimePoint>::equal,
+            ts.tail(2),
+            polars::SecondsTimeSeries({2, 3}, {t2_p, t3_p})
+    );
 
-        EXPECT_PRED2(polars::TimeSeries<TimePoint>::equal, ts.head(10), ts);
+    EXPECT_PRED2(polars::TimeSeries<TimePoint>::equal, ts.head(10), ts);
 
-    }
+}
 
-    TEST(TimeSeries, left_shift_operator_test) {
-        // Method work as expected
-        using TimePoint = time_point<system_clock, seconds>;
+TEST(TimeSeries, left_shift_operator_test) {
+    // Method work as expected
+    using TimePoint = time_point<system_clock, seconds>;
 
-        time_t t1 = 1525971600;
-        time_t t2 = 1525971780;
-        time_t t3 = 1525971960;
+    time_t t1 = 1525971600;
+    time_t t2 = 1525971780;
+    time_t t3 = 1525971960;
 
-        TimePoint t1_p{duration_cast<minutes>(polars::unix_epoch_seconds(t1))};
-        TimePoint t2_p{duration_cast<minutes>(polars::unix_epoch_seconds(t2))};
-        TimePoint t3_p{duration_cast<minutes>(polars::unix_epoch_seconds(t3))};
+    TimePoint t1_p{duration_cast<minutes>(polars::unix_epoch_seconds(t1))};
+    TimePoint t2_p{duration_cast<minutes>(polars::unix_epoch_seconds(t2))};
+    TimePoint t3_p{duration_cast<minutes>(polars::unix_epoch_seconds(t3))};
 
-        std::vector<TimePoint> tpoints = {t1_p, t2_p, t3_p};
-        arma::vec vals = {1, 2, 3};
+    std::vector<TimePoint> tpoints = {t1_p, t2_p, t3_p};
+    arma::vec vals = {1, 2, 3};
 
-        // Build TimeSeries
-        polars::SecondsTimeSeries ts = polars::SecondsTimeSeries(vals, tpoints);
+    // Build TimeSeries
+    polars::SecondsTimeSeries ts = polars::SecondsTimeSeries(vals, tpoints);
 
-        std::ostringstream ss;
-        ss << ts;
-        ASSERT_EQ(
-                ss.str(),
-                "Timeseries: \nTimestamp:\n2018 May 10 17:00:00 Value:\n1Timestamp:\n2018 May 10 17:03:00 Value:\n2Timestamp:\n2018 May 10 17:06:00 Value:\n3"
-        );
-    }
+    std::ostringstream ss;
+    ss << ts;
+    ASSERT_EQ(
+            ss.str(),
+            "Timeseries: \nTimestamp:\n2018 May 10 17:00:00 Value:\n1Timestamp:\n2018 May 10 17:03:00 Value:\n2Timestamp:\n2018 May 10 17:06:00 Value:\n3"
+    );
+}
 } // namespace TimeSeriesTests

--- a/tests/test_cpp/polars/TestTimeSeries.cpp
+++ b/tests/test_cpp/polars/TestTimeSeries.cpp
@@ -50,6 +50,26 @@ TEST(TimeSeries, constructor) {
     ) << "Expect " << " timestamps in milliseconds";
 
     // TODO deal with duplicate values in constructor one way or the other
+
+
+    using SecTP = time_point<system_clock, seconds>;
+    using HourTP = time_point<system_clock, hours>;
+
+    EXPECT_PRED2(DaysTimeSeries::equal, DaysTimeSeries(DaysTimeSeriesMask()), DaysTimeSeries())
+                        << "Expect constructing with empty SeriesMask is the same as empty constructor";
+    EXPECT_PRED2(
+            SecondsTimeSeries::equal,
+            SecondsTimeSeries(SecondsTimeSeriesMask({true, false}, {SecTP(1s), SecTP(2s)})),
+            SecondsTimeSeries({1, 0}, {SecTP(1s), SecTP(2s)})
+    ) << "Expect true becomes 1 and false becomes 0";
+
+    auto foo = [](HoursTimeSeries s) { return s; };
+    EXPECT_PRED2(
+            HoursTimeSeries::equal,
+            foo(HoursTimeSeriesMask({true, false}, {HourTP(1h), HourTP(2h)})),
+            HoursTimeSeries({1, 0}, {HourTP(1h), HourTP(2h)})
+    ) << "Expect implicit conversion from SeriesMask to Series is possible so that you can pass a SeriesMask to a function expecting a Series";
+
 }
 
 TEST(TimeSeries, from_map) {


### PR DESCRIPTION
This adds a [converting constructor](https://en.cppreference.com/w/cpp/language/converting_constructor) to the `Series` and `TimeSeries` types to allow them to be created from a `...Mask` type.

I decided to make these implicit as the conversion is lossless but this choice is worth a review.