### PR TITLE
Convert between Series and TimeSeries

### DIFF
--- a/src/cpp/polars/TimeSeries.h
+++ b/src/cpp/polars/TimeSeries.h
@@ -58,6 +58,11 @@ namespace polars {
             return {values, index};
         }
 
+        /**
+         * enable explicit conversion from a Series to a TimeSeries when you *know* the value match
+         */
+        static TimeSeries from_series(const Series& ser) {return ser;};
+
         // TODO: Rename to_map once we sort out base methods, etc.
         std::map<TimePointType, double> to_timeseries_map() const {
             std::map<TimePointType, double> m;

--- a/tests/test_cpp/polars/TestTimeSeries.cpp
+++ b/tests/test_cpp/polars/TestTimeSeries.cpp
@@ -86,6 +86,20 @@ TEST(TimeSeries, from_map) {
 
 }
 
+TEST(TimeSeries, from_series) {
+    using TP = time_point<system_clock, seconds>;
+
+    EXPECT_PRED2(SecondsTimeSeries::equal, SecondsTimeSeries::from_series({}), SecondsTimeSeries());
+
+    auto ts = SecondsTimeSeries({3, 4}, {TP(1s), TP(2s)});
+    EXPECT_PRED2(SecondsTimeSeries::equal, SecondsTimeSeries::from_series(Series(ts)), ts)
+                        << "Expect perfect round trip conversions when comparing as TimeSeries";
+
+    auto s = Series({3, 4}, {1, 2});
+    EXPECT_PRED2(Series::equal, Series(SecondsTimeSeries::from_series(s)), s)
+                        << "Expect perfect round trip conversions when comparing as Series";
+}
+
 TEST(TimeSeries, get_timestamps) {
 
     using TimePoint = time_point<system_clock, seconds>;


### PR DESCRIPTION
The `TimeSeries` template has a private constructor that means member methods can construct a `TimeSeries` from a `Series` - this is helpful when using the `Series` implementation and converting back again. While all `Series` functionality may be exposed through a `TimeSeries` eventually, for now it much easier to allow the `TimeSeries` to call `Series` methods, get back a `Series`, and let the caller convert back to a `TimeSeries` with the correct `TimeSeries<TimePoint>` type explicitly.

This PR adds an explicit `TimeSeries<SomeTimePoint>::from_series()` static method that allows users to convert when they know the type used to create the `Series`.