### PR TITLE
Adding from_series_mask to TimeSeriesMask

### DIFF
--- a/src/cpp/polars/TimeSeriesMask.h
+++ b/src/cpp/polars/TimeSeriesMask.h
@@ -36,6 +36,11 @@ namespace polars {
 
         TimeSeriesMask(arma::uvec v0, std::vector<TimePointType> t0) : SeriesMask(v0, chrono_to_double_vector(t0)) {};
 
+        /**
+         * enable explicit conversion from a SeriesMask to a TimeSeriesMask when you *know* the value match
+         */
+        static TimeSeriesMask from_series_mask(const SeriesMask& mask) {return mask;};
+
         std::vector<TimePointType> timestamps() const {
             // Pass indices and return vector of timepoints
             return double_to_chrono_vector(index());
@@ -91,6 +96,7 @@ namespace polars {
         };
 
     private:
+        TimeSeriesMask(const SeriesMask& mask) : SeriesMask(mask) {};
         static double chrono_to_double(TimePointType timepoint){
             return time_point_cast<typename TimePointType::duration>(timepoint).time_since_epoch().count();
         };

--- a/tests/test_cpp/polars/TestTimeSeriesMask.cpp
+++ b/tests/test_cpp/polars/TestTimeSeriesMask.cpp
@@ -13,6 +13,7 @@
 
 
 using namespace std::chrono;
+using namespace polars;
 
 TEST(TimeSeriesMask, constructor) {
 
@@ -46,6 +47,20 @@ TEST(TimeSeriesMask, constructor) {
             ts.index(),
             arma::vec({1525971600000, 1525971780000}) // in milliseconds
     ) << "Expect " << " timestamps in milliseconds";
+}
+
+TEST(TimeSeriesMask, from_series_mask) {
+    using TP = time_point<system_clock, seconds>;
+
+    EXPECT_PRED2(SecondsTimeSeriesMask::equal, SecondsTimeSeriesMask::from_series_mask({}), SecondsTimeSeriesMask());
+
+    auto ts = SecondsTimeSeriesMask({3, 4}, {TP(1s), TP(2s)});
+    EXPECT_PRED2(SecondsTimeSeriesMask::equal, SecondsTimeSeriesMask::from_series_mask(SeriesMask(ts)), ts)
+                        << "Expect perfect round trip conversions when comparing as TimeSeriesMask";
+
+    auto s = SeriesMask({3, 4}, {1, 2});
+    EXPECT_PRED2(SeriesMask::equal, SeriesMask(SecondsTimeSeriesMask::from_series_mask(s)), s)
+                        << "Expect perfect round trip conversions when comparing as SeriesMask";
 }
 
 TEST(TimeSeriesMask, get_timestamps) {


### PR DESCRIPTION
A `TimeSeries` can be created from a Series by explicitly casting if the scale of the stored values is known - this allows for the same for a `TimeSeriesMask`.