### PR TITLE
Add from_map method to TimeSeriesMask

### DIFF
--- a/src/cpp/polars/TimeSeries.h
+++ b/src/cpp/polars/TimeSeries.h
@@ -150,11 +150,11 @@ std::ostream &operator<<(std::ostream &os, const polars::TimeSeries<TimePointTyp
     std::vector<TimePointType> timestamps = ts.timestamps();
     arma::vec vals = ts.values();
 
-    os << "Timeseries: \n";
+    os << "Timeseries:\n";
 
     for (auto& pair : ts.head(5).to_timeseries_map()) {
         time_t elem = std::chrono::system_clock::to_time_t(pair.first);
-        os << "Timestamp:\n" << std::put_time(std::gmtime(&elem), "%Y %b %d %H:%M:%S") << " Value:\n" << pair.second;
+        os << "Timestamp:\t" << std::put_time(std::gmtime(&elem), "%Y %b %d %H:%M:%S") << "\tValue:\t" << pair.second << "\n";
     }
 
     if(ts.size() > 5){
@@ -162,7 +162,7 @@ std::ostream &operator<<(std::ostream &os, const polars::TimeSeries<TimePointTyp
 
         for (auto& pair : ts.tail(5).to_timeseries_map()) {
             time_t elem = std::chrono::system_clock::to_time_t(pair.first);
-            os << "Timestamp:\n" << std::put_time(std::gmtime(&elem), "%Y %b %d %H:%M:%S") << " Value:\n" << pair.second;
+            os << "Timestamp:\t" << std::put_time(std::gmtime(&elem), "%Y %b %d %H:%M:%S") << "\tValue:\t" << pair.second << "\n";
         }
     }
 

--- a/src/cpp/polars/TimeSeriesMask.h
+++ b/src/cpp/polars/TimeSeriesMask.h
@@ -34,7 +34,7 @@ namespace polars {
 
         TimeSeriesMask() = default;
 
-        TimeSeriesMask(arma::uvec v0, std::vector<TimePointType> t0) : SeriesMask(v0, chrono_to_double_vector(t0)) {};
+        TimeSeriesMask(arma::uvec v0, std::vector<TimePointType> t0) : SeriesMask(v0 > 0, chrono_to_double_vector(t0)) {};
 
         static TimeSeriesMask from_map(const std::map<TimePointType, bool> &iv_map) {
             arma::vec index(iv_map.size());
@@ -160,7 +160,7 @@ std::ostream &operator<<(std::ostream &os, const polars::TimeSeriesMask<TimePoin
     std::vector<TimePointType> timestamps = ts.timestamps();
     arma::uvec vals = ts.values();
 
-    os << "TimeSeriesMask: \n";
+    os << "TimeSeriesMask:\n";
 
     for (auto& pair : ts.head(5).to_timeseries_map()) {
         time_t elem = std::chrono::system_clock::to_time_t(pair.first);

--- a/src/cpp/polars/TimeSeriesMask.h
+++ b/src/cpp/polars/TimeSeriesMask.h
@@ -164,7 +164,7 @@ std::ostream &operator<<(std::ostream &os, const polars::TimeSeriesMask<TimePoin
 
     for (auto& pair : ts.head(5).to_timeseries_map()) {
         time_t elem = std::chrono::system_clock::to_time_t(pair.first);
-        os << "Timestamp:\n" << std::put_time(std::gmtime(&elem), "%Y %b %d %H:%M:%S") << " Value:\n" << pair.second;
+        os << "Timestamp:\t" << std::put_time(std::gmtime(&elem), "%Y %b %d %H:%M:%S") << "\tValue:\t" << pair.second << "\n";
     }
 
     if(ts.size() > 5){
@@ -172,7 +172,7 @@ std::ostream &operator<<(std::ostream &os, const polars::TimeSeriesMask<TimePoin
 
         for (auto& pair : ts.tail(5).to_timeseries_map()) {
             time_t elem = std::chrono::system_clock::to_time_t(pair.first);
-            os << "Timestamp:\n" << std::put_time(std::gmtime(&elem), "%Y %b %d %H:%M:%S") << " Value:\n" << pair.second;
+            os << "Timestamp:\t" << std::put_time(std::gmtime(&elem), "%Y %b %d %H:%M:%S") << "\tValue:\t" << pair.second << "\n";
         }
     }
 

--- a/src/cpp/polars/TimeSeriesMask.h
+++ b/src/cpp/polars/TimeSeriesMask.h
@@ -36,6 +36,18 @@ namespace polars {
 
         TimeSeriesMask(arma::uvec v0, std::vector<TimePointType> t0) : SeriesMask(v0, chrono_to_double_vector(t0)) {};
 
+        static TimeSeriesMask from_map(const std::map<TimePointType, bool> &iv_map) {
+            arma::vec index(iv_map.size());
+            arma::uvec values(iv_map.size());
+            int i = 0;
+            for (auto& pair : iv_map) {
+                index[i] = chrono_to_double(pair.first);
+                values[i] = pair.second;
+                ++i;
+            }
+            return {values, index};
+        }
+
         /**
          * enable explicit conversion from a SeriesMask to a TimeSeriesMask when you *know* the value match
          */
@@ -96,7 +108,9 @@ namespace polars {
         };
 
     private:
+        TimeSeriesMask(arma::uvec v0, arma::vec t0) : SeriesMask(v0, t0) {};
         TimeSeriesMask(const SeriesMask& mask) : SeriesMask(mask) {};
+
         static double chrono_to_double(TimePointType timepoint){
             return time_point_cast<typename TimePointType::duration>(timepoint).time_since_epoch().count();
         };

--- a/src/cpp/polars/TimeSeriesMask.h
+++ b/src/cpp/polars/TimeSeriesMask.h
@@ -126,7 +126,7 @@ namespace polars {
 
 
         static TimePointType double_to_chrono(double timestamp){
-            return TimePointType{duration_cast<typename TimePointType::duration>(unix_epoch_seconds(timestamp))};
+            return TimePointType{typename TimePointType::duration(std::lround(timestamp))};
         };
 
         static std::vector<TimePointType> double_to_chrono_vector(const arma::vec& tstamps){

--- a/tests/test_cpp/polars/TestTimeSeries.cpp
+++ b/tests/test_cpp/polars/TestTimeSeries.cpp
@@ -283,7 +283,7 @@ TEST(TimeSeries, prettyprint) {
     out << ts;
 
     EXPECT_EQ(out.str(),
-              "Timeseries: \nTimestamp:\n2018 May 10 17:00:00 Value:\n1Timestamp:\n2018 May 10 17:03:00 Value:\n2");
+              "Timeseries:\nTimestamp:\t2018 May 10 17:00:00\tValue:\t1\nTimestamp:\t2018 May 10 17:03:00\tValue:\t2\n");
 
 }
 
@@ -343,7 +343,7 @@ TEST(TimeSeries, left_shift_operator_test) {
     ss << ts;
     ASSERT_EQ(
             ss.str(),
-            "Timeseries: \nTimestamp:\n2018 May 10 17:00:00 Value:\n1Timestamp:\n2018 May 10 17:03:00 Value:\n2Timestamp:\n2018 May 10 17:06:00 Value:\n3"
+            "Timeseries:\nTimestamp:\t2018 May 10 17:00:00\tValue:\t1\nTimestamp:\t2018 May 10 17:03:00\tValue:\t2\nTimestamp:\t2018 May 10 17:06:00\tValue:\t3\n"
     );
 }
 } // namespace TimeSeriesTests

--- a/tests/test_cpp/polars/TestTimeSeriesMask.cpp
+++ b/tests/test_cpp/polars/TestTimeSeriesMask.cpp
@@ -220,7 +220,7 @@ TEST(TimeSeriesMask, prettyprint) {
     out << ts;
 
     EXPECT_EQ(out.str(),
-              "TimeSeriesMask: \nTimestamp:\n2018 May 10 17:00:00 Value:\n1Timestamp:\n2018 May 10 17:03:00 Value:\n0");
+              "TimeSeriesMask:\nTimestamp:\t2018 May 10 17:00:00\tValue:\t1\nTimestamp:\t2018 May 10 17:03:00\tValue:\t0\n");
 
 }
 
@@ -280,6 +280,6 @@ TEST(TimeSeriesMask, left_shift_operator_test) {
     ss << ts;
     ASSERT_EQ(
             ss.str(),
-            "TimeSeriesMask: \nTimestamp:\n2018 May 10 17:00:00 Value:\n1Timestamp:\n2018 May 10 17:03:00 Value:\n0Timestamp:\n2018 May 10 17:06:00 Value:\n1"
+            "TimeSeriesMask:\nTimestamp:\t2018 May 10 17:00:00\tValue:\t1\nTimestamp:\t2018 May 10 17:03:00\tValue:\t0\nTimestamp:\t2018 May 10 17:06:00\tValue:\t1\n"
     );
 }

--- a/tests/test_cpp/polars/TestTimeSeriesMask.cpp
+++ b/tests/test_cpp/polars/TestTimeSeriesMask.cpp
@@ -49,6 +49,40 @@ TEST(TimeSeriesMask, constructor) {
     ) << "Expect " << " timestamps in milliseconds";
 }
 
+TEST(TimeSeriesMask, from_map) {
+    using TP = time_point<system_clock, seconds>;
+
+    EXPECT_PRED2(SecondsTimeSeriesMask::equal, SecondsTimeSeriesMask::from_map({}), SecondsTimeSeriesMask());
+
+    EXPECT_PRED2(
+            SecondsTimeSeriesMask::equal,
+            SecondsTimeSeriesMask::from_map({{TP(1s), 3},
+                                         {TP(2s), 4}}),
+            SecondsTimeSeriesMask({3, 4}, {TP(1s), TP(2s)})
+    );
+
+    using MTP = time_point<system_clock, minutes>;
+
+    auto ts = MinutesTimeSeriesMask({3, 4}, {MTP(1min), MTP(2min)});
+    EXPECT_PRED2(
+            MinutesTimeSeriesMask::equal,
+            MinutesTimeSeriesMask::from_map(ts.to_timeseries_map()),
+            ts
+    );
+
+    using MSTP = time_point<system_clock, milliseconds>;
+
+    auto ms_ts = MillisecondsTimeSeriesMask({3, 4}, {MSTP(1min), MSTP(2min)});
+    EXPECT_PRED2(
+            MillisecondsTimeSeriesMask::equal,
+            MillisecondsTimeSeriesMask::from_map(ms_ts.to_timeseries_map()),
+            ms_ts
+    );
+
+
+
+}
+
 TEST(TimeSeriesMask, from_series_mask) {
     using TP = time_point<system_clock, seconds>;
 


### PR DESCRIPTION
This adds a `TimeSeriesMask::from_map` method to aid in simple construction. It also tidies up the printing and fixes some bugs that became apparent in adding this method.