### PR TITLE
add cmake options to toggle submodule dependencies and tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,7 @@ option(WITH_TESTS "Build polars_cpp_test target" ON)
 
 if(WITH_SUBMODULE_DEPENDENCIES)
   # Dependencies
-  set(DEPENDENCIES_DIR "dependencies")
-  include(${DEPENDENCIES_DIR}/CMakeLists.txt)
+  include(dependencies/CMakeLists.txt)
 endif()
 
 # Include other CMakeLists.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,9 +4,18 @@ project(Polars C CXX)
 
 set(CMAKE_CXX_STANDARD 14)
 
-# Dependencies
-set(DEPENDENCIES_DIR "dependencies")
+option(WITH_SUBMODULE_DEPENDENCIES "Use submodules for dependencies" ON)
+option(WITH_TESTS "Build polars_cpp_test target" ON)
+
+if(WITH_SUBMODULE_DEPENDENCIES)
+  # Dependencies
+  set(DEPENDENCIES_DIR "dependencies")
+  include(${DEPENDENCIES_DIR}/CMakeLists.txt)
+endif()
 
 # Include other CMakeLists.txt
 include(src/cpp/polars/CMakeLists.txt)
-include(tests/test_cpp/polars/CMakeLists.txt)
+
+if(WITH_TESTS)
+  include(tests/test_cpp/polars/CMakeLists.txt)
+endif()

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -1,0 +1,3 @@
+
+add_subdirectory(${DEPENDENCIES_DIR}/date)
+add_subdirectory(${DEPENDENCIES_DIR}/armadillo-code)

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -1,3 +1,3 @@
 
-add_subdirectory(${DEPENDENCIES_DIR}/date)
-add_subdirectory(${DEPENDENCIES_DIR}/armadillo-code)
+add_subdirectory(dependencies/date)
+add_subdirectory(dependencies/armadillo-code)

--- a/scripts/build-with-cmake-withflags.sh
+++ b/scripts/build-with-cmake-withflags.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 (mkdir -p build/cmake-makefile-debug
 cd build/cmake-makefile-debug
-cmake -DCMAKE_BUILD_TYPE=Debug -G "Unix Makefiles" ../.. 
+cmake -DCMAKE_BUILD_TYPE=Debug -DWITH_TESTS=OFF -DWITH_SUBMODULE_DEPENDENCIES=OFF -G "Unix Makefiles" ../..
 cmake --build . --target all -- -j 2)

--- a/scripts/run-cpp-tests.sh
+++ b/scripts/run-cpp-tests.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-build/cmake-makefile-debug/cpp_test
+build/cmake-makefile-debug/polars_cpp_test

--- a/src/cpp/polars/CMakeLists.txt
+++ b/src/cpp/polars/CMakeLists.txt
@@ -1,6 +1,3 @@
-# add dependencies
-add_subdirectory(${DEPENDENCIES_DIR}/date)
-add_subdirectory(${DEPENDENCIES_DIR}/armadillo-code)
 
 # Set source directory
 set(CPP_SOURCE_DIR "src/cpp/polars")


### PR DESCRIPTION
## Problem

In order to wrap the Polars library as a [conan](https://conan.io/) package, it needs to be build-able in a way that:
* doesn't manually resolve dependencies
* doesn't build test sources


## Solution

Change the stack of CMakeLists.txt files to allow dependencies and tests to be toggled off using CMake options. 

This PR introduces 2 CMake options that, if not set, will not change existing behaviour:
* `WITH_SUBMODULE_DEPENDENCIES`
* `WITH_TESTS `