### PR TITLE
Excludes directories when exporting sources

### DIFF
--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -17,7 +17,7 @@ class PolarsConan(ConanFile):
     options = {"shared": [True, False]}
     default_options = "shared=False"
     generators = "cmake"
-    exports_sources = "../*", "!../dependencies*", "!../scripts*", "!../build*"
+    exports_sources = "../*", "!dependencies/*", "!build"
     requires = "Armadillo/9.200.1@felix/stable", "Date/2.4.1@felix/stable"
 
     def build(self):


### PR DESCRIPTION
## Description
Building using projects with referenced Polars using conan was resulting in linker errors. Upon further debugging, this was due to conflicting artefacts being generated as part of the build step. 

This PR excludes certain source directories from being exported to ensure the correct .a files are available for linking.
