### PR TITLE
removes unnecessary cmake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,11 +4,10 @@ project(Polars C CXX)
 
 set(CMAKE_CXX_STANDARD 14)
 
-option(WITH_SUBMODULE_DEPENDENCIES "Use submodules for dependencies" ON)
 option(WITH_TESTS "Build polars_cpp_test target" ON)
 option(BUILD_WITH_CONAN "Resolve dependencies using conan" OFF)
 
-if(WITH_SUBMODULE_DEPENDENCIES)
+if(NOT BUILD_WITH_CONAN)
   # Dependencies
   include(dependencies/CMakeLists.txt)
 endif()

--- a/README.md
+++ b/README.md
@@ -34,8 +34,11 @@ To install - WIP (need to add the install() command to the CMakeLists.txt)
 
 ```
 cd conan
-conan create . user/channel -s cppstd=14
+conan create . felix/stable -s cppstd=14
 ```
+...where `felix` refers to the name of the user / company creating the package, and
+`stable` refers to the channel (or distribution scope) of the library.
+
 
 Building with Conan requires:
 * `Armadillo/9.200.1@felix/stable` ([repo](https://github.com/felix-org/conan-armadillo))

--- a/README.md
+++ b/README.md
@@ -34,10 +34,9 @@ To install - WIP (need to add the install() command to the CMakeLists.txt)
 
 ```
 cd conan
-conan create . felix/stable -s cppstd=14
+conan create . felix/master -s cppstd=14
 ```
-...where `felix` refers to the name of the user / company creating the package, and
-`stable` refers to the channel (or distribution scope) of the library.
+...where `felix/master` refers to an official release that comes from a merge-commit on the master branch. Any other builds should be under `username/dev`
 
 
 Building with Conan requires:

--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -23,7 +23,6 @@ class PolarsConan(ConanFile):
     def build(self):
         cmake = CMake(self)
         cmake.definitions["WITH_TESTS"] = "OFF"
-        cmake.definitions["WITH_SUBMODULE_DEPENDENCIES"] = "OFF"
         cmake.definitions["BUILD_WITH_CONAN"] = "ON"
         cmake.configure()
         cmake.build()


### PR DESCRIPTION
## Description
The `WITH_SUBMODULE_DEPENDENCIES` cmake option is no longer necessary with the introduction of `BUILD_WITH_CONAN`.
This PR removes it and updates the conan configuration accordingly