### PR TITLE
Bugs in rolling method

### DIFF
--- a/src/cpp/polars/Series.cpp
+++ b/src/cpp/polars/Series.cpp
@@ -330,6 +330,7 @@ namespace polars {
     }
 
     // TODO: This method needs to be re-factored.
+    // TODO: Combine cases here with those in input for exponential case.
     polars::Series _window_size_correction(int window_size, bool center, const polars::Series &input){
         // assume that this function only gets called when window_size > input.size()
 
@@ -367,7 +368,7 @@ namespace polars {
 
             new_input =arma::join_cols(single_nan, arma::join_cols(single_nan, input.values()));
 
-            // passing goes at the end
+            // passing goes on the left x2
             new_index_0 = index_0 - 2 * delta;
             new_timestamps = arma::linspace(new_index_0, ts.at(ts.size()-1), 2 + input.size() );
 

--- a/src/cpp/polars/Series.h
+++ b/src/cpp/polars/Series.h
@@ -155,6 +155,10 @@ namespace polars {
     };
 
     std::ostream &operator<<(std::ostream &os, const Series &ts);
+
+
+    polars::Series _window_size_correction(int window_size, bool center, const polars::Series &input);
+    polars::Series _ewm_input_correction(const polars::Series &input);
 }
 
 

--- a/tests/test_cpp/polars/TestSeries.cpp
+++ b/tests/test_cpp/polars/TestSeries.cpp
@@ -623,4 +623,47 @@ TEST(Series, tail) {
     );
 }
 
+TEST(Series, rolling_window_size_correction){
+
+    arma::vec input_values = {0.1, 0.3, 0.5, 0.4, 0.7, 0.9, 0.3, 0.1};
+    arma::vec input_timestamps = {1, 2, 3, 4, 5, 6, 7, 8};
+
+    Series new_input_series = _window_size_correction(10, false, Series(input_values, input_timestamps));
+
+    EXPECT_PRED2(
+        Series::equal,
+        new_input_series,
+        Series({NAN, NAN, NAN, NAN, 0.1, 0.3, 0.5, 0.4, 0.7, 0.9, 0.3, 0.1},
+               {-3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8})
+    ) << "Expect" << " additional 4 NANs at the beginning for window size even";
+
+    new_input_series = _window_size_correction(11, false, Series(input_values, input_timestamps));
+
+    EXPECT_PRED2(
+        Series::equal,
+        new_input_series,
+        Series({NAN, NAN, NAN, NAN, 0.1, 0.3, 0.5, 0.4, 0.7, 0.9, 0.3, 0.1},
+               {-3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8})
+    ) << "Expect" << " additional 4 NANs at the beginning for window size odd";
+
+    input_timestamps = {0, 3, 6, 9, 12, 15, 18, 21};
+
+    new_input_series = _window_size_correction(10, false, Series(input_values, input_timestamps));
+
+    EXPECT_PRED2(
+        Series::equal,
+        new_input_series,
+        Series({NAN, NAN, NAN, NAN, 0.1, 0.3, 0.5, 0.4, 0.7, 0.9, 0.3, 0.1},
+               {-12, -9, -6, -3, 0, 3, 6, 9, 12, 15, 18, 21})
+    ) << "Expect" << " additional 4 NANs at the beginning for window size odd";
+}
+
+TEST(Series, rolling_exp_input_correction){
+
+    EXPECT_PRED2(Series::equal, Series(), _ewm_input_correction({})) << "Expect" << " empty input series to return empty series";
+    EXPECT_PRED2(Series::equal, Series({NAN, NAN, NAN, 5, 6, 7}, {-2, -1, 0, 1, 2, 3}), _ewm_input_correction({{5, 6, 7}, {1, 2, 3}}));
+    EXPECT_PRED2(Series::equal, Series({NAN, NAN, NAN, NAN, 5, 6, 7, 8}, {-3, -2, -1, 0, 1, 2, 3, 4}), _ewm_input_correction({{5, 6, 7, 8}, {1, 2, 3, 4}}));
+
+}
+
 } // namespace SeriesTests


### PR DESCRIPTION
This PR addresses bugs related rolling calculations. Additional test coverage is provided. 

Note: As a todo, further understanding of the interplay between center, symmetric, input size and window size is required.