### PR TITLE
BUG: Exponential rolling window fix for front NAN bugs

### DIFF
--- a/src/cpp/polars/Series.h
+++ b/src/cpp/polars/Series.h
@@ -71,6 +71,8 @@ namespace polars {
 
         double iloc(arma::uword pos) const;
 
+        Series iloc(int from, int to, int step = 1) const;
+
         Series loc(const arma::vec &index_labels) const;
 
         Series loc(arma::uword) const;

--- a/src/cpp/polars/SeriesMask.cpp
+++ b/src/cpp/polars/SeriesMask.cpp
@@ -21,7 +21,40 @@ namespace polars {
         //assert(!arma::any(v > 1));  // Np SeriesMask values may be greater than 1
     };
 
-    // TODO: Add slicing logic of the form .iloc(int start, int stop, int step=1) so it can be called like ser.iloc(0, -10).
+    SeriesMask SeriesMask::iloc(int from, int to, int step) const {
+
+        if(empty()  || (from == to)){
+            return SeriesMask();
+        }
+
+        arma::uvec pos;
+        int effective_from;
+        int effective_to;
+
+        if(from < 0){
+            effective_from = values().size() + from;
+        } else {
+            effective_from = from;
+        }
+
+        if(to < 0){
+            effective_to = values().size() + to - 1;
+        } else if(to == 0) {
+            effective_to = to;
+        } else {
+            effective_to = to - 1;
+        }
+
+        pos = arma::regspace<arma::uvec>(effective_from,  step,  effective_to);
+
+        if(pos.size() > size()){
+            pos = pos.subvec(0, size() - 1);
+        }
+
+        return SeriesMask(values().elem(pos),index().elem(pos));
+    }
+
+// TODO: Add slicing logic of the form .iloc(int start, int stop, int step=1) so it can be called like ser.iloc(0, -10).
     SeriesMask SeriesMask::iloc(const arma::uvec &pos) const {
         return SeriesMask(values().elem(pos), index().elem(pos));
     }

--- a/src/cpp/polars/SeriesMask.h
+++ b/src/cpp/polars/SeriesMask.h
@@ -27,6 +27,8 @@ namespace polars {
 
         double iloc(arma::uword pos) const;
 
+        SeriesMask iloc(int from, int to, int step = 1) const;
+
         SeriesMask loc(const arma::vec &index_labels) const;
 
         SeriesMask loc(arma::uword) const;

--- a/tests/test_cpp/polars/TestSeries.cpp
+++ b/tests/test_cpp/polars/TestSeries.cpp
@@ -471,18 +471,109 @@ TEST(Series, quantile) {
 
 TEST(Series, iloc) {
 
-    auto indices = arma::uvec{1, 2};
-
     EXPECT_PRED2(
-            Series::equal,
-            Series({20, 40, 34, 10}, {1, 2, 3, 4}).iloc(indices),
-            Series({40, 34}, {2, 3})) << "Expect " << "subset including specified indices to be retrieved";
+        Series::equal,
+        Series(),
+        Series().iloc(1,3)
+    ) << "Expect " << "empty series";
 
 
     EXPECT_EQ(
-            Series({1, 2, 3, 4}, {1, 2, 3, 4}).iloc(2),
-            3
+        Series({1, 2, 3, 4}, {1, 2, 3, 4}).iloc(2),
+        3
     ) << "Expect " << " element 3 to be retrieved";
+
+    EXPECT_PRED2(
+        Series::equal,
+        Series({1, 2}, {1, 2}).iloc(0, 0),
+        Series({}, {})
+    )  << "Expect " << " empty series";
+
+    EXPECT_PRED2(
+        Series::equal,
+        Series({1, 2}, {1, 2}).iloc(2, 2),
+        Series({}, {})
+    )  << "Expect " << " empty series";
+
+
+    EXPECT_PRED2(
+        Series::equal,
+        Series({1, 2}, {1, 2}).iloc(0, 10),
+        Series({1, 2}, {1, 2})
+    )  << "Expect " << " same series since to > series size and from is positive";
+
+    EXPECT_PRED2(
+        Series::equal,
+        Series({0,1,2,3}, {0,1,2,3}),
+        Series({0,1,2,3}, {0,1,2,3}).iloc(0, 4)
+    ) << "Expect " << " same series since to > series size and from is positive";
+
+    EXPECT_PRED2(
+        Series::equal,
+        Series({0, 2}, {0, 2}),
+        Series({0, 1, 2, 3, 4, 5, 6, 7}, {0, 1, 2, 3, 4, 5, 6, 7}).iloc(0,4,2)
+    ) << "Expect " << " slice of series with step 2";
+
+    EXPECT_PRED2(
+        Series::equal,
+        Series({7, 8, 9, 10, 11, 12}, {7, 8, 9, 10, 11, 12}).iloc(1, 6),
+        Series({8, 9, 10, 11, 12}, {8, 9, 10, 11, 12})
+    ) << "Expect " << " subseries given from and to > 0 ";
+
+    EXPECT_PRED2(
+        Series::equal,
+        Series({}, {}).iloc(-4, -2),
+        Series({}, {})
+    )  << "Expect " << " empty series input sliced to give empty series";
+
+    EXPECT_PRED2(
+        Series::equal,
+        Series({3, 4, 5, 6}, {3, 4, 5, 6}).iloc(2, -1),
+        Series({5}, {5})
+    ) << "Expect " << " third element given positive from, and negative to";
+
+    EXPECT_PRED2(
+        Series::equal,
+        Series({3, 4, 5, 6}, {3, 4, 5, 6}).iloc(-3, -1),
+        Series({4, 5}, {4, 5})
+    ) << "Expect " << " middle elements given negative from, and negative to";
+
+    EXPECT_PRED2(
+        Series::equal,
+        Series({10,11}, {10,11}),
+        Series({7, 8, 9, 10, 11, 12}, {7, 8, 9, 10, 11, 12}).iloc(-3, 5)
+    ) << "Expect " << " middle elements given negative from, and positive to";
+
+    EXPECT_PRED2(
+        Series::equal,
+        Series({12}, {12}),
+        Series({7, 8, 9, 10, 11, 12}, {7, 8, 9, 10, 11, 12}).iloc(-1, 6)
+    ) << "Expect " << " last element given negative from, and positive to of the size of the series";
+
+    EXPECT_PRED2(
+        Series::equal,
+        Series({10, 11, 12}, {10, 11, 12}),
+        Series({7, 8, 9, 10, 11, 12}, {7, 8, 9, 10, 11, 12}).iloc(-3, 6)
+    ) << "Expect " << " last elements given negative from, and positive to of the size of the series";
+
+    EXPECT_PRED2(
+        Series::equal,
+        Series({3, 4, 5, 6, 7}, {3, 4, 5, 6, 7}).iloc(-3, 0),
+        Series()
+    ) << " empty series";
+
+    EXPECT_PRED2(
+        Series::equal,
+        Series({3, 4, 5, 6}, {3, 4, 5, 6}).iloc(0, -3),
+        Series({3}, {3})
+    ) << " first element given negative value of size of array + 1";
+
+    auto indices = arma::uvec{1, 2};
+
+    EXPECT_PRED2(
+        Series::equal,
+        Series({20, 40, 34, 10}, {1, 2, 3, 4}).iloc(indices),
+        Series({40, 34}, {2, 3})) << "Expect " << "subset including specified indices to be retrieved";
 
 }
 

--- a/tests/test_cpp/polars/TestWindowProcessor.cpp
+++ b/tests/test_cpp/polars/TestWindowProcessor.cpp
@@ -834,4 +834,55 @@ TEST(Series, rolling_mean_exponential) {
 }
 
 
+TEST(Series, rolling_mean_exponential_NAN) {
+
+    arma::vec inp(6);
+    inp.fill(NAN);
+
+    EXPECT_PRED2(
+        Series::equal,
+        Series({NAN, NAN, 2, 3, NAN, 4}, {1, 2, 3, 4, 5, 6}).rolling(10, polars::ExpMean(), 1, false, false,
+                                                             polars::WindowProcessor::WindowType::expn, 0.5),
+        Series({NAN, NAN, 2.0, 2.6666666666666665, 2.6666666666666665, 3.6363636363636362}, {1, 2, 3, 4, 5, 6})
+    ) << "Expect " << " same result as without nans when window size is larger than array and intermediate NAN";
+
+    EXPECT_PRED2(
+        Series::equal,
+        Series({NAN, NAN, 2, 3, 4}, {1, 2, 3, 4, 5}).rolling(10, polars::ExpMean(), 1, false, false,
+                                                             polars::WindowProcessor::WindowType::expn, 0.5),
+        Series({NAN, NAN, 2.0, 2.6666666666666665, 3.4285714285714284}, {1, 2, 3, 4, 5})
+    ) << "Expect " << " same result as without nans when window size is larger than array";
+
+    EXPECT_PRED2(
+        Series::equal,
+        Series({NAN, NAN, 2, 3, 4}, {1, 2, 3, 4, 5}).rolling(3, polars::ExpMean(), 1, false, false,
+                                                 polars::WindowProcessor::WindowType::expn, 0.5),
+        Series({NAN, NAN, 2.0, 2.6666666666666665, 3.4285714285714284}, {1, 2, 3, 4, 5})
+    ) << "Expect " << " same result as without nans when window size is smaller than array";
+
+    EXPECT_PRED2(
+        Series::equal,
+        Series({NAN, NAN, 2}, {1, 2, 3}).rolling(3, polars::ExpMean(), 1, false, false,
+                                         polars::WindowProcessor::WindowType::expn, 0.5),
+        Series({NAN, NAN, 2}, {1, 2, 3})
+    ) << "Expect " << "identity preserving two nans";
+
+
+    EXPECT_PRED2(
+        Series::equal,
+        Series({NAN, 2}, {1, 2}).rolling(3, polars::ExpMean(), 1, false, false,
+                                                                         polars::WindowProcessor::WindowType::expn, 0.5),
+        Series({NAN, 2}, {1, 2})
+    ) << "Expect " << "identity preserving one nan";
+
+    EXPECT_PRED2(
+        Series::equal,
+        Series(inp, {1, 2, 3, 4, 5, 6}).rolling(6, polars::ExpMean(), 1, false, false,
+                                                polars::WindowProcessor::WindowType::expn, 0.5),
+        Series(inp, {1, 2, 3, 4, 5, 6})
+    ) << "Expect " << "with a window of 6, all nans back";
+
+}
+
+
 } // namespace SeriesTests

--- a/tests/test_cpp/polars/TestWindowProcessor.cpp
+++ b/tests/test_cpp/polars/TestWindowProcessor.cpp
@@ -356,6 +356,13 @@ TEST(Series, rolling_sum_triangle) {
     ) << "Expect " << "with a window of 2";
 
     EXPECT_PRED2(
+        Series::equal,
+        Series({NAN, 1, 2, 3}, {0, 1, 2, 3}).rolling(2, polars::Sum(), 0, true, false,
+                                             polars::WindowProcessor::WindowType::triang),
+        Series({NAN, NAN, 1.5, 2.5}, {0, 1, 2, 3})
+    ) << "Expect " << "with a window of 2";
+
+    EXPECT_PRED2(
             Series::equal,
             Series({1, 2, 3.5, -1, NAN}, {1, 2, 3, 4, 5}).rolling(3, polars::Sum(), 0, true, false,
                                                                   polars::WindowProcessor::WindowType::triang),
@@ -441,6 +448,10 @@ TEST(Series, rolling_mean_triangle) {
 
 
 TEST(Series, edge_cases_with_NAN){
+
+    EXPECT_PRED2(Series::equal, Series({1},{1}).rolling(1, 0, true, false, polars::WindowProcessor::WindowType::triang).mean(),
+                 Series({1}, {1})
+    );
 
     EXPECT_PRED2(
         Series::almost_equal,


### PR DESCRIPTION
This fixes the issue with inputs having NANs at the beginning given that we are forced to pad inputs when the window size is smaller than the array size.